### PR TITLE
APIクライアント作成時の戻り値をinterfaceに変更

### DIFF
--- a/internal/tools/gen-api-op/main.go
+++ b/internal/tools/gen-api-op/main.go
@@ -52,7 +52,7 @@ type {{ .TypeName }}Op struct{
 }
 
 // New{{ $typeName}}Op creates new {{ $typeName}}Op instance
-func New{{ $typeName}}Op(client APICaller) *{{ $typeName}}Op {
+func New{{ $typeName}}Op(client APICaller) {{ $typeName}}API {
 	return &{{ $typeName}}Op {
     	Client: client,
 		PathSuffix: "{{.GetPathSuffix}}",

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -24,7 +24,7 @@ type CDROMOp struct {
 }
 
 // NewCDROMOp creates new CDROMOp instance
-func NewCDROMOp(client APICaller) *CDROMOp {
+func NewCDROMOp(client APICaller) CDROMAPI {
 	return &CDROMOp{
 		Client:     client,
 		PathSuffix: "api/cloud/1.1",
@@ -320,7 +320,7 @@ type NFSOp struct {
 }
 
 // NewNFSOp creates new NFSOp instance
-func NewNFSOp(client APICaller) *NFSOp {
+func NewNFSOp(client APICaller) NFSAPI {
 	return &NFSOp{
 		Client:     client,
 		PathSuffix: "api/cloud/1.1",
@@ -716,7 +716,7 @@ type NoteOp struct {
 }
 
 // NewNoteOp creates new NoteOp instance
-func NewNoteOp(client APICaller) *NoteOp {
+func NewNoteOp(client APICaller) NoteAPI {
 	return &NoteOp{
 		Client:     client,
 		PathSuffix: "api/cloud/1.1",
@@ -941,7 +941,7 @@ type SwitchOp struct {
 }
 
 // NewSwitchOp creates new SwitchOp instance
-func NewSwitchOp(client APICaller) *SwitchOp {
+func NewSwitchOp(client APICaller) SwitchAPI {
 	return &SwitchOp{
 		Client:     client,
 		PathSuffix: "api/cloud/1.1",
@@ -1213,7 +1213,7 @@ type ZoneOp struct {
 }
 
 // NewZoneOp creates new ZoneOp instance
-func NewZoneOp(client APICaller) *ZoneOp {
+func NewZoneOp(client APICaller) ZoneAPI {
 	return &ZoneOp{
 		Client:     client,
 		PathSuffix: "api/cloud/1.1",


### PR DESCRIPTION
利用者のテストを容易にするため、以下のようなコードでAPIクライアントを作成する場合の戻り値をinterfaceに変更する。

```go
// これまではZoneOp(concrete)が返っていたのをZoneAPI(interface)を返すように
client := sacloud.NewZoneOp(apiCaller)
```

**Note**: 現状はxxxOpとxxxAPIをinternal/defineから生成しているが、この方法だとxxxOpにジェネレーションギャップを利用した手書き処理を追加できない。このため今後コード生成方法を変更し、xxxOpをソースとしてxxxAPIを生成する必要がある。