### PR TITLE
mapconvの改善

### DIFF
--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -107,7 +107,7 @@ func (f *fieldsDef) NFSClass() *schema.FieldDesc {
 		ReadOnly: true,
 		Type:     meta.TypeString,
 		Tags: &schema.FieldTags{
-			MapConv: ":nfs",
+			MapConv: ",default=nfs",
 		},
 	}
 }
@@ -118,7 +118,7 @@ func (f *fieldsDef) GSLBProviderClass() *schema.FieldDesc {
 		ReadOnly: true,
 		Type:     meta.TypeString,
 		Tags: &schema.FieldTags{
-			MapConv: "Provider.Class:gslb",
+			MapConv: "Provider.Class,default=gslb",
 		},
 	}
 }
@@ -191,7 +191,7 @@ func (f *fieldsDef) GSLBDelayLoop() *schema.FieldDesc {
 		Type: meta.TypeInt,
 		Tags: &schema.FieldTags{
 			Validate: "min=10,max=60",
-			MapConv:  "Settings.GSLB.DelayLoop:10",
+			MapConv:  "Settings.GSLB.DelayLoop,default=10",
 		},
 	}
 }

--- a/pkg/mapconv/mapconv_test.go
+++ b/pkg/mapconv/mapconv_test.go
@@ -342,5 +342,11 @@ func TestRecursive(t *testing.T) {
 		err := ConvertTo(tc.input, dest)
 		require.NoError(t, err)
 		require.Equal(t, tc.expect, dest)
+
+		// reverse
+		source := &recursiveSource{}
+		err = ConvertFrom(tc.expect, source)
+		require.NoError(t, err)
+		require.Equal(t, tc.input, source)
 	}
 }

--- a/pkg/mapconv/mapconv_test.go
+++ b/pkg/mapconv/mapconv_test.go
@@ -237,7 +237,7 @@ func TestInsertInnerSlice(t *testing.T) {
 }
 
 type hasDefaultSource struct {
-	Field string `mapconv:"Field:default-value"`
+	Field string `mapconv:"Field,default=default-value"`
 }
 
 type hasDefaultDest struct {
@@ -266,7 +266,7 @@ func TestDefaultValue(t *testing.T) {
 }
 
 type multipleSource struct {
-	Field string `mapconv:"Field1,Field2"`
+	Field string `mapconv:"Field1/Field2"`
 }
 
 type multipleDest struct {
@@ -292,6 +292,53 @@ func TestMultipleDestination(t *testing.T) {
 
 	for _, tc := range expects {
 		dest := &multipleDest{}
+		err := ConvertTo(tc.input, dest)
+		require.NoError(t, err)
+		require.Equal(t, tc.expect, dest)
+	}
+}
+
+type recursiveSource struct {
+	Field *recursiveSourceChild `mapconv:",recursive"`
+}
+
+type recursiveSourceChild struct {
+	Field1 string `mapconv:"Dest1"`
+	Field2 string `mapconv:"Dest2"`
+}
+
+type recursiveDest struct {
+	Field *recursiveDestChild
+}
+
+type recursiveDestChild struct {
+	Dest1 string
+	Dest2 string
+}
+
+func TestRecursive(t *testing.T) {
+	expects := []struct {
+		input  *recursiveSource
+		expect *recursiveDest
+	}{
+		{
+			input: &recursiveSource{
+				Field: &recursiveSourceChild{
+					Field1: "value1",
+					Field2: "value2",
+				},
+			},
+			expect: &recursiveDest{
+				Field: &recursiveDestChild{
+					Dest1: "value1",
+					Dest2: "value2",
+				},
+			},
+		},
+	}
+
+	for _, tc := range expects {
+		dest := &recursiveDest{}
 		err := ConvertTo(tc.input, dest)
 		require.NoError(t, err)
 		require.Equal(t, tc.expect, dest)

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -533,10 +533,10 @@ type GSLB struct {
 	Icon                    *naked.Icon `json:",omitempty"`
 	CreatedAt               *time.Time
 	ModifiedAt              *time.Time
-	Class                   string `mapconv:"Provider.Class:gslb"`
+	Class                   string `mapconv:"Provider.Class,default=gslb"`
 	SettingsHash            string
 	FQDN                    string              `mapconv:"Status.FQDN"`
-	DelayLoop               int                 `mapconv:"Settings.GSLB.DelayLoop:10" validate:"min=10,max=60"`
+	DelayLoop               int                 `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
 	Weighted                types.StringFlag    `mapconv:"Settings.GSLB.Weighted"`
 	HealthCheckProtocol     string              `mapconv:"Settings.GSLB.HealthCheck.Protocol" validate:"oneof=http https ping tcp"`
 	HealthCheckHostHeader   string              `mapconv:"Settings.GSLB.HealthCheck.Host"`
@@ -775,13 +775,13 @@ func (o *GSLB) convertFrom(naked *naked.GSLB) error {
 
 // GSLBCreateRequest represents API parameter/response structure
 type GSLBCreateRequest struct {
-	Class                   string              `mapconv:"Provider.Class:gslb"`
+	Class                   string              `mapconv:"Provider.Class,default=gslb"`
 	HealthCheckProtocol     string              `mapconv:"Settings.GSLB.HealthCheck.Protocol" validate:"oneof=http https ping tcp"`
 	HealthCheckHostHeader   string              `mapconv:"Settings.GSLB.HealthCheck.Host"`
 	HealthCheckPath         string              `mapconv:"Settings.GSLB.HealthCheck.Path"`
 	HealthCheckResponseCode types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Status"`
 	HealthCheckPort         types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Port"`
-	DelayLoop               int                 `mapconv:"Settings.GSLB.DelayLoop:10" validate:"min=10,max=60"`
+	DelayLoop               int                 `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
 	Weighted                types.StringFlag    `mapconv:"Settings.GSLB.Weighted"`
 	SorryServer             string              `mapconv:"Settings.GSLB.SorryServer"`
 	DestinationServers      []*naked.GSLBServer `mapconv:"Settings.GSLB.Servers" validate:"min=0,max=6"`
@@ -954,7 +954,7 @@ type GSLBUpdateRequest struct {
 	HealthCheckPath         string              `mapconv:"Settings.GSLB.HealthCheck.Path"`
 	HealthCheckResponseCode types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Status"`
 	HealthCheckPort         types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Port"`
-	DelayLoop               int                 `mapconv:"Settings.GSLB.DelayLoop:10" validate:"min=10,max=60"`
+	DelayLoop               int                 `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
 	Weighted                types.StringFlag    `mapconv:"Settings.GSLB.Weighted"`
 	SorryServer             string              `mapconv:"Settings.GSLB.SorryServer"`
 	DestinationServers      []*naked.GSLBServer `mapconv:"Settings.GSLB.Servers" validate:"min=0,max=6"`
@@ -1363,7 +1363,7 @@ func (o *NFS) convertFrom(naked *naked.NFS) error {
 
 // NFSCreateRequest represents API parameter/response structure
 type NFSCreateRequest struct {
-	Class          string   `mapconv:":nfs"`
+	Class          string   `mapconv:",default=nfs"`
 	SwitchID       types.ID `mapconv:"Remark.Switch.ID"`
 	PlanID         types.ID `mapconv:"Remark.Plan.ID,Plan.ID"`
 	IPAddress      string   `mapconv:"Remark.[]Servers.IPAddress"`


### PR DESCRIPTION
mapconvでのタグの記法を変更する。

旧: `mapconv:"field1,field2:default"`
新: `mapconv:"field1/field2,default=default,omitempty,recursive"`

- カンマ区切りで複数項目を指定する
- 最初の項目は宛先フィールド名とする
- 宛先フィールド名は`/`区切りで複数指定可能
- 2番目以降の項目は順不同で以下を指定可能
  - `default`: デフォルト値、`default=value`の形で記載する
  - `omitempty`: 指定した場合、値が空(structs#Fields.IsZeroがtrue)の場合はマッピング処理を行わない
  - `recursive`: 指定した場合、マッピング時に再帰マッピングを行う
