### PR TITLE
GSLBスキーマの更新

### DIFF
--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -209,9 +209,35 @@ func (f *fieldsDef) GSLBWeighted() *schema.FieldDesc {
 func (f *fieldsDef) GSLBDestinationServers() *schema.FieldDesc {
 	return &schema.FieldDesc{
 		Name: "DestinationServers",
-		Type: meta.Static([]*naked.GSLBServer{}),
+		Type: &schema.Model{
+			Name:    "GSLBServer",
+			IsArray: true,
+			Fields: []*schema.FieldDesc{
+				{
+					Name: "IPAddress",
+					Type: meta.TypeString,
+					Tags: &schema.FieldTags{
+						Validate: "ipv4",
+					},
+				},
+				{
+					Name: "Enabled",
+					Type: meta.TypeStringFlag,
+					Tags: &schema.FieldTags{
+						MapConv: ",default=true",
+					},
+				},
+				{
+					Name: "Weight",
+					Type: meta.TypeStringNumber,
+					Tags: &schema.FieldTags{
+						MapConv: ",default=1",
+					},
+				},
+			},
+		},
 		Tags: &schema.FieldTags{
-			MapConv:  "Settings.GSLB.Servers",
+			MapConv:  "Settings.GSLB.[]Servers,recursive",
 			Validate: "min=0,max=6",
 		},
 	}

--- a/internal/schema/operation.go
+++ b/internal/schema/operation.go
@@ -285,13 +285,16 @@ func (o *Operation) ResultsStatement() string {
 func (o *Operation) Models() Models {
 	ms := o.results.Models()
 	for _, arg := range o.MapDestinationDeciders() {
-		ms = append(ms, arg.DestinationModel())
+		m := arg.DestinationModel()
+		ms = append(ms, m)
+		ms = append(ms, m.FieldModels()...)
+
 	}
+
 	for _, arg := range o.PassthroughFieldDeciders() {
-		ms = append(ms, arg.DestinationModel())
-	}
-	for _, res := range o.results {
-		ms = append(ms, res.Model)
+		m := arg.DestinationModel()
+		ms = append(ms, m)
+		ms = append(ms, m.FieldModels()...)
 	}
 	return Models(ms).UniqByName()
 }

--- a/pkg/mapconv/mapconv_test.go
+++ b/pkg/mapconv/mapconv_test.go
@@ -316,6 +316,14 @@ type recursiveDestChild struct {
 	Dest2 string
 }
 
+type recursiveSourceSlice struct {
+	Fields []*recursiveSourceChild `mapconv:"[]Slice,recursive"`
+}
+
+type recursiveDestSlice struct {
+	Slice []*recursiveDestChild
+}
+
 func TestRecursive(t *testing.T) {
 	expects := []struct {
 		input  *recursiveSource
@@ -345,6 +353,53 @@ func TestRecursive(t *testing.T) {
 
 		// reverse
 		source := &recursiveSource{}
+		err = ConvertFrom(tc.expect, source)
+		require.NoError(t, err)
+		require.Equal(t, tc.input, source)
+	}
+}
+
+func TestRecursiveSlice(t *testing.T) {
+	expects := []struct {
+		input  *recursiveSourceSlice
+		expect *recursiveDestSlice
+	}{
+		{
+			input: &recursiveSourceSlice{
+				Fields: []*recursiveSourceChild{
+					{
+						Field1: "value1",
+						Field2: "value2",
+					},
+					{
+						Field1: "value3",
+						Field2: "value4",
+					},
+				},
+			},
+			expect: &recursiveDestSlice{
+				Slice: []*recursiveDestChild{
+					{
+						Dest1: "value1",
+						Dest2: "value2",
+					},
+					{
+						Dest1: "value3",
+						Dest2: "value4",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range expects {
+		dest := &recursiveDestSlice{}
+		err := ConvertTo(tc.input, dest)
+		require.NoError(t, err)
+		require.Equal(t, tc.expect, dest)
+
+		// reverse
+		source := &recursiveSourceSlice{}
 		err = ConvertFrom(tc.expect, source)
 		require.NoError(t, err)
 		require.Equal(t, tc.input, source)

--- a/sacloud/gslb_op_test.go
+++ b/sacloud/gslb_op_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sacloud/libsacloud-v2/sacloud/naked"
 	"github.com/sacloud/libsacloud-v2/sacloud/types"
 )
 
@@ -63,15 +62,9 @@ var (
 		DelayLoop:               20,
 		Weighted:                types.StringTrue,
 		SorryServer:             "8.8.8.8",
-		DestinationServers: []*naked.GSLBServer{
-			{
-				IPAddress: "192.2.0.1",
-				Enabled:   types.StringTrue,
-			},
-			{
-				IPAddress: "192.2.0.2",
-				Enabled:   types.StringTrue,
-			},
+		DestinationServers: []*GSLBServer{
+			{IPAddress: "192.2.0.1"},
+			{IPAddress: "192.2.0.2"},
 		},
 	}
 	createGSLBExpected = &GSLB{
@@ -87,16 +80,7 @@ var (
 		HealthCheckResponseCode: createGSLBParam.HealthCheckResponseCode,
 		HealthCheckPort:         createGSLBParam.HealthCheckPort,
 		SorryServer:             createGSLBParam.SorryServer,
-		DestinationServers: []*naked.GSLBServer{
-			{
-				IPAddress: "192.2.0.1",
-				Enabled:   types.StringTrue,
-			},
-			{
-				IPAddress: "192.2.0.2",
-				Enabled:   types.StringTrue,
-			},
-		},
+		DestinationServers:      createGSLBParam.DestinationServers,
 	}
 	updateGSLBParam = &GSLBUpdateRequest{
 		Name:                    "libsacloud-v2-gslb-upd",
@@ -109,16 +93,16 @@ var (
 		DelayLoop:               21,
 		Weighted:                types.StringTrue,
 		SorryServer:             "8.8.4.4",
-		DestinationServers: []*naked.GSLBServer{
+		DestinationServers: []*GSLBServer{
 			{
-				IPAddress: "192.2.1.1",
-				Enabled:   types.StringTrue,
-				Weight:    types.StringNumber(1000),
+				IPAddress: "192.2.0.11",
+				Enabled:   types.StringFalse,
+				Weight:    types.StringNumber(100),
 			},
 			{
-				IPAddress: "192.2.1.2",
-				Enabled:   types.StringTrue,
-				Weight:    types.StringNumber(1000),
+				IPAddress: "192.2.0.21",
+				Enabled:   types.StringFalse,
+				Weight:    types.StringNumber(200),
 			},
 		},
 	}
@@ -135,18 +119,7 @@ var (
 		HealthCheckResponseCode: updateGSLBParam.HealthCheckResponseCode,
 		HealthCheckPort:         updateGSLBParam.HealthCheckPort,
 		SorryServer:             updateGSLBParam.SorryServer,
-		DestinationServers: []*naked.GSLBServer{
-			{
-				IPAddress: "192.2.1.1",
-				Enabled:   types.StringTrue,
-				Weight:    types.StringNumber(1000),
-			},
-			{
-				IPAddress: "192.2.1.2",
-				Enabled:   types.StringTrue,
-				Weight:    types.StringNumber(1000),
-			},
-		},
+		DestinationServers:      updateGSLBParam.DestinationServers,
 	}
 )
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -535,16 +535,16 @@ type GSLB struct {
 	ModifiedAt              *time.Time
 	Class                   string `mapconv:"Provider.Class,default=gslb"`
 	SettingsHash            string
-	FQDN                    string              `mapconv:"Status.FQDN"`
-	DelayLoop               int                 `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
-	Weighted                types.StringFlag    `mapconv:"Settings.GSLB.Weighted"`
-	HealthCheckProtocol     string              `mapconv:"Settings.GSLB.HealthCheck.Protocol" validate:"oneof=http https ping tcp"`
-	HealthCheckHostHeader   string              `mapconv:"Settings.GSLB.HealthCheck.Host"`
-	HealthCheckPath         string              `mapconv:"Settings.GSLB.HealthCheck.Path"`
-	HealthCheckResponseCode types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Status"`
-	HealthCheckPort         types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Port"`
-	SorryServer             string              `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers      []*naked.GSLBServer `mapconv:"Settings.GSLB.Servers" validate:"min=0,max=6"`
+	FQDN                    string             `mapconv:"Status.FQDN"`
+	DelayLoop               int                `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
+	Weighted                types.StringFlag   `mapconv:"Settings.GSLB.Weighted"`
+	HealthCheckProtocol     string             `mapconv:"Settings.GSLB.HealthCheck.Protocol" validate:"oneof=http https ping tcp"`
+	HealthCheckHostHeader   string             `mapconv:"Settings.GSLB.HealthCheck.Host"`
+	HealthCheckPath         string             `mapconv:"Settings.GSLB.HealthCheck.Path"`
+	HealthCheckResponseCode types.StringNumber `mapconv:"Settings.GSLB.HealthCheck.Status"`
+	HealthCheckPort         types.StringNumber `mapconv:"Settings.GSLB.HealthCheck.Port"`
+	SorryServer             string             `mapconv:"Settings.GSLB.SorryServer"`
+	DestinationServers      []*GSLBServer      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=6"`
 }
 
 // Validate validates by field tags
@@ -748,12 +748,12 @@ func (o *GSLB) SetSorryServer(v string) {
 }
 
 // GetDestinationServers returns value of DestinationServers
-func (o *GSLB) GetDestinationServers() []*naked.GSLBServer {
+func (o *GSLB) GetDestinationServers() []*GSLBServer {
 	return o.DestinationServers
 }
 
 // SetDestinationServers sets value to DestinationServers
-func (o *GSLB) SetDestinationServers(v []*naked.GSLBServer) {
+func (o *GSLB) SetDestinationServers(v []*GSLBServer) {
 	o.DestinationServers = v
 }
 
@@ -775,17 +775,17 @@ func (o *GSLB) convertFrom(naked *naked.GSLB) error {
 
 // GSLBCreateRequest represents API parameter/response structure
 type GSLBCreateRequest struct {
-	Class                   string              `mapconv:"Provider.Class,default=gslb"`
-	HealthCheckProtocol     string              `mapconv:"Settings.GSLB.HealthCheck.Protocol" validate:"oneof=http https ping tcp"`
-	HealthCheckHostHeader   string              `mapconv:"Settings.GSLB.HealthCheck.Host"`
-	HealthCheckPath         string              `mapconv:"Settings.GSLB.HealthCheck.Path"`
-	HealthCheckResponseCode types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Status"`
-	HealthCheckPort         types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Port"`
-	DelayLoop               int                 `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
-	Weighted                types.StringFlag    `mapconv:"Settings.GSLB.Weighted"`
-	SorryServer             string              `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers      []*naked.GSLBServer `mapconv:"Settings.GSLB.Servers" validate:"min=0,max=6"`
-	Name                    string              `validate:"required"`
+	Class                   string             `mapconv:"Provider.Class,default=gslb"`
+	HealthCheckProtocol     string             `mapconv:"Settings.GSLB.HealthCheck.Protocol" validate:"oneof=http https ping tcp"`
+	HealthCheckHostHeader   string             `mapconv:"Settings.GSLB.HealthCheck.Host"`
+	HealthCheckPath         string             `mapconv:"Settings.GSLB.HealthCheck.Path"`
+	HealthCheckResponseCode types.StringNumber `mapconv:"Settings.GSLB.HealthCheck.Status"`
+	HealthCheckPort         types.StringNumber `mapconv:"Settings.GSLB.HealthCheck.Port"`
+	DelayLoop               int                `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
+	Weighted                types.StringFlag   `mapconv:"Settings.GSLB.Weighted"`
+	SorryServer             string             `mapconv:"Settings.GSLB.SorryServer"`
+	DestinationServers      []*GSLBServer      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=6"`
+	Name                    string             `validate:"required"`
 	Description             string
 	Tags                    []string
 	IconID                  types.ID `mapconv:"Icon.ID"`
@@ -882,12 +882,12 @@ func (o *GSLBCreateRequest) SetSorryServer(v string) {
 }
 
 // GetDestinationServers returns value of DestinationServers
-func (o *GSLBCreateRequest) GetDestinationServers() []*naked.GSLBServer {
+func (o *GSLBCreateRequest) GetDestinationServers() []*GSLBServer {
 	return o.DestinationServers
 }
 
 // SetDestinationServers sets value to DestinationServers
-func (o *GSLBCreateRequest) SetDestinationServers(v []*naked.GSLBServer) {
+func (o *GSLBCreateRequest) SetDestinationServers(v []*GSLBServer) {
 	o.DestinationServers = v
 }
 
@@ -944,21 +944,67 @@ func (o *GSLBCreateRequest) convertFrom(naked *naked.GSLB) error {
 }
 
 /*************************************************
+* GSLBServer
+*************************************************/
+
+// GSLBServer represents API parameter/response structure
+type GSLBServer struct {
+	IPAddress string             `validate:"ipv4"`
+	Enabled   types.StringFlag   `mapconv:",default=true"`
+	Weight    types.StringNumber `mapconv:",default=1"`
+}
+
+// Validate validates by field tags
+func (o *GSLBServer) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetIPAddress returns value of IPAddress
+func (o *GSLBServer) GetIPAddress() string {
+	return o.IPAddress
+}
+
+// SetIPAddress sets value to IPAddress
+func (o *GSLBServer) SetIPAddress(v string) {
+	o.IPAddress = v
+}
+
+// GetEnabled returns value of Enabled
+func (o *GSLBServer) GetEnabled() types.StringFlag {
+	return o.Enabled
+}
+
+// SetEnabled sets value to Enabled
+func (o *GSLBServer) SetEnabled(v types.StringFlag) {
+	o.Enabled = v
+}
+
+// GetWeight returns value of Weight
+func (o *GSLBServer) GetWeight() types.StringNumber {
+	return o.Weight
+}
+
+// SetWeight sets value to Weight
+func (o *GSLBServer) SetWeight(v types.StringNumber) {
+	o.Weight = v
+}
+
+/*************************************************
 * GSLBUpdateRequest
 *************************************************/
 
 // GSLBUpdateRequest represents API parameter/response structure
 type GSLBUpdateRequest struct {
-	HealthCheckProtocol     string              `mapconv:"Settings.GSLB.HealthCheck.Protocol" validate:"oneof=http https ping tcp"`
-	HealthCheckHostHeader   string              `mapconv:"Settings.GSLB.HealthCheck.Host"`
-	HealthCheckPath         string              `mapconv:"Settings.GSLB.HealthCheck.Path"`
-	HealthCheckResponseCode types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Status"`
-	HealthCheckPort         types.StringNumber  `mapconv:"Settings.GSLB.HealthCheck.Port"`
-	DelayLoop               int                 `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
-	Weighted                types.StringFlag    `mapconv:"Settings.GSLB.Weighted"`
-	SorryServer             string              `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers      []*naked.GSLBServer `mapconv:"Settings.GSLB.Servers" validate:"min=0,max=6"`
-	Name                    string              `validate:"required"`
+	HealthCheckProtocol     string             `mapconv:"Settings.GSLB.HealthCheck.Protocol" validate:"oneof=http https ping tcp"`
+	HealthCheckHostHeader   string             `mapconv:"Settings.GSLB.HealthCheck.Host"`
+	HealthCheckPath         string             `mapconv:"Settings.GSLB.HealthCheck.Path"`
+	HealthCheckResponseCode types.StringNumber `mapconv:"Settings.GSLB.HealthCheck.Status"`
+	HealthCheckPort         types.StringNumber `mapconv:"Settings.GSLB.HealthCheck.Port"`
+	DelayLoop               int                `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
+	Weighted                types.StringFlag   `mapconv:"Settings.GSLB.Weighted"`
+	SorryServer             string             `mapconv:"Settings.GSLB.SorryServer"`
+	DestinationServers      []*GSLBServer      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=6"`
+	Name                    string             `validate:"required"`
 	Description             string
 	Tags                    []string
 	IconID                  types.ID `mapconv:"Icon.ID"`
@@ -1050,12 +1096,12 @@ func (o *GSLBUpdateRequest) SetSorryServer(v string) {
 }
 
 // GetDestinationServers returns value of DestinationServers
-func (o *GSLBUpdateRequest) GetDestinationServers() []*naked.GSLBServer {
+func (o *GSLBUpdateRequest) GetDestinationServers() []*GSLBServer {
 	return o.DestinationServers
 }
 
 // SetDestinationServers sets value to DestinationServers
-func (o *GSLBUpdateRequest) SetDestinationServers(v []*naked.GSLBServer) {
+func (o *GSLBUpdateRequest) SetDestinationServers(v []*GSLBServer) {
 	o.DestinationServers = v
 }
 


### PR DESCRIPTION
(related: #17) 

schema.FieldDescのTypeとしてschema.Modelを指定可能にすることで #17での問題を解決する。

これにより、GSLBでの実サーバ登録は以下のようにすることが可能となる。

```go
	createGSLBParam = &GSLBCreateRequest{
		// ...
		DestinationServers: []*GSLBServer{
			{IPAddress: "192.2.0.1"},
			{IPAddress: "192.2.0.2"},
		},
	}
```
