### PR TITLE
エンベロープの非公開化

### DIFF
--- a/internal/schema/functions.go
+++ b/internal/schema/functions.go
@@ -47,3 +47,7 @@ func normalizeResourceName(name string) string {
 	}
 	return n
 }
+
+func toCamelWithFirstLower(name string) string {
+	return xstrings.FirstRuneToLower(xstrings.ToCamelCase(strings.Replace(normalizeResourceName(name), "-", "_", -1)))
+}

--- a/internal/schema/operation.go
+++ b/internal/schema/operation.go
@@ -261,12 +261,12 @@ func (o *Operation) PassthroughSimpleFieldDeciders() []PassthroughSimpleFieldDec
 
 // RequestEnvelopeStructName エンベロープのstruct名
 func (o *Operation) RequestEnvelopeStructName() string {
-	return fmt.Sprintf("%s%sRequestEnvelope", o.resource.name, o.name)
+	return fmt.Sprintf("%s%sRequestEnvelope", toCamelWithFirstLower(o.resource.name), o.name)
 }
 
 // ResponseEnvelopeStructName エンベロープのstruct名
 func (o *Operation) ResponseEnvelopeStructName() string {
-	return fmt.Sprintf("%s%sResponseEnvelope", o.resource.name, o.name)
+	return fmt.Sprintf("%s%sResponseEnvelope", toCamelWithFirstLower(o.resource.name), o.name)
 }
 
 // AllArguments 設定されている全てのArgumentを取得

--- a/internal/schema/operation_test.go
+++ b/internal/schema/operation_test.go
@@ -65,8 +65,8 @@ func TestOperation(t *testing.T) {
 				}),
 			expect: &expectOperationValues{
 				methodName:                 "Create",
-				requestEnvelopeStructName:  "TestCreateRequestEnvelope",
-				responseEnvelopeStructName: "TestCreateResponseEnvelope",
+				requestEnvelopeStructName:  "testCreateRequestEnvelope",
+				responseEnvelopeStructName: "testCreateResponseEnvelope",
 				requestPayloadName:         "Test",
 				responsePayloadName:        "Test",
 			},

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -52,9 +52,9 @@ func (o *ArchiveOp) Find(ctx context.Context, zone string, conditions *FindCondi
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &ArchiveFindRequestEnvelope{}
+			body = &archiveFindRequestEnvelope{}
 		}
-		v := body.(*ArchiveFindRequestEnvelope)
+		v := body.(*archiveFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -66,7 +66,7 @@ func (o *ArchiveOp) Find(ctx context.Context, zone string, conditions *FindCondi
 		return nil, err
 	}
 
-	nakedResponse := &ArchiveFindResponseEnvelope{}
+	nakedResponse := &archiveFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -102,9 +102,9 @@ func (o *ArchiveOp) Create(ctx context.Context, zone string, param *ArchiveCreat
 			param = &ArchiveCreateRequest{}
 		}
 		if body == nil {
-			body = &ArchiveCreateRequestEnvelope{}
+			body = &archiveCreateRequestEnvelope{}
 		}
-		v := body.(*ArchiveCreateRequestEnvelope)
+		v := body.(*archiveCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -118,7 +118,7 @@ func (o *ArchiveOp) Create(ctx context.Context, zone string, param *ArchiveCreat
 		return nil, err
 	}
 
-	nakedResponse := &ArchiveCreateResponseEnvelope{}
+	nakedResponse := &archiveCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -150,9 +150,9 @@ func (o *ArchiveOp) CreateBlank(ctx context.Context, zone string, param *Archive
 			param = &ArchiveCreateBlankRequest{}
 		}
 		if body == nil {
-			body = &ArchiveCreateBlankRequestEnvelope{}
+			body = &archiveCreateBlankRequestEnvelope{}
 		}
-		v := body.(*ArchiveCreateBlankRequestEnvelope)
+		v := body.(*archiveCreateBlankRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, nil, err
@@ -166,7 +166,7 @@ func (o *ArchiveOp) CreateBlank(ctx context.Context, zone string, param *Archive
 		return nil, nil, err
 	}
 
-	nakedResponse := &ArchiveCreateBlankResponseEnvelope{}
+	nakedResponse := &archiveCreateBlankResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, nil, err
 	}
@@ -202,7 +202,7 @@ func (o *ArchiveOp) Read(ctx context.Context, zone string, id types.ID) (*Archiv
 		return nil, err
 	}
 
-	nakedResponse := &ArchiveReadResponseEnvelope{}
+	nakedResponse := &archiveReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -235,9 +235,9 @@ func (o *ArchiveOp) Update(ctx context.Context, zone string, id types.ID, param 
 			param = &ArchiveUpdateRequest{}
 		}
 		if body == nil {
-			body = &ArchiveUpdateRequestEnvelope{}
+			body = &archiveUpdateRequestEnvelope{}
 		}
-		v := body.(*ArchiveUpdateRequestEnvelope)
+		v := body.(*archiveUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -251,7 +251,7 @@ func (o *ArchiveOp) Update(ctx context.Context, zone string, id types.ID, param 
 		return nil, err
 	}
 
-	nakedResponse := &ArchiveUpdateResponseEnvelope{}
+	nakedResponse := &archiveUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -306,9 +306,9 @@ func (o *ArchiveOp) OpenFTP(ctx context.Context, zone string, id types.ID, openO
 			openOption = &OpenFTPRequest{}
 		}
 		if body == nil {
-			body = &ArchiveOpenFTPRequestEnvelope{}
+			body = &archiveOpenFTPRequestEnvelope{}
 		}
-		v := body.(*ArchiveOpenFTPRequestEnvelope)
+		v := body.(*archiveOpenFTPRequestEnvelope)
 		if err := mapconv.ConvertTo(openOption, v); err != nil {
 			return nil, err
 		}
@@ -320,7 +320,7 @@ func (o *ArchiveOp) OpenFTP(ctx context.Context, zone string, id types.ID, openO
 		return nil, err
 	}
 
-	nakedResponse := &ArchiveOpenFTPResponseEnvelope{}
+	nakedResponse := &archiveOpenFTPResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -397,9 +397,9 @@ func (o *CDROMOp) Find(ctx context.Context, zone string, conditions *FindConditi
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &CDROMFindRequestEnvelope{}
+			body = &cdromFindRequestEnvelope{}
 		}
-		v := body.(*CDROMFindRequestEnvelope)
+		v := body.(*cdromFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -411,7 +411,7 @@ func (o *CDROMOp) Find(ctx context.Context, zone string, conditions *FindConditi
 		return nil, err
 	}
 
-	nakedResponse := &CDROMFindResponseEnvelope{}
+	nakedResponse := &cdromFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -447,9 +447,9 @@ func (o *CDROMOp) Create(ctx context.Context, zone string, param *CDROMCreateReq
 			param = &CDROMCreateRequest{}
 		}
 		if body == nil {
-			body = &CDROMCreateRequestEnvelope{}
+			body = &cdromCreateRequestEnvelope{}
 		}
-		v := body.(*CDROMCreateRequestEnvelope)
+		v := body.(*cdromCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, nil, err
@@ -463,7 +463,7 @@ func (o *CDROMOp) Create(ctx context.Context, zone string, param *CDROMCreateReq
 		return nil, nil, err
 	}
 
-	nakedResponse := &CDROMCreateResponseEnvelope{}
+	nakedResponse := &cdromCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, nil, err
 	}
@@ -499,7 +499,7 @@ func (o *CDROMOp) Read(ctx context.Context, zone string, id types.ID) (*CDROM, e
 		return nil, err
 	}
 
-	nakedResponse := &CDROMReadResponseEnvelope{}
+	nakedResponse := &cdromReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -532,9 +532,9 @@ func (o *CDROMOp) Update(ctx context.Context, zone string, id types.ID, param *C
 			param = &CDROMUpdateRequest{}
 		}
 		if body == nil {
-			body = &CDROMUpdateRequestEnvelope{}
+			body = &cdromUpdateRequestEnvelope{}
 		}
-		v := body.(*CDROMUpdateRequestEnvelope)
+		v := body.(*cdromUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -548,7 +548,7 @@ func (o *CDROMOp) Update(ctx context.Context, zone string, id types.ID, param *C
 		return nil, err
 	}
 
-	nakedResponse := &CDROMUpdateResponseEnvelope{}
+	nakedResponse := &cdromUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -603,9 +603,9 @@ func (o *CDROMOp) OpenFTP(ctx context.Context, zone string, id types.ID, openOpt
 			openOption = &OpenFTPRequest{}
 		}
 		if body == nil {
-			body = &CDROMOpenFTPRequestEnvelope{}
+			body = &cdromOpenFTPRequestEnvelope{}
 		}
-		v := body.(*CDROMOpenFTPRequestEnvelope)
+		v := body.(*cdromOpenFTPRequestEnvelope)
 		if err := mapconv.ConvertTo(openOption, v); err != nil {
 			return nil, err
 		}
@@ -617,7 +617,7 @@ func (o *CDROMOp) OpenFTP(ctx context.Context, zone string, id types.ID, openOpt
 		return nil, err
 	}
 
-	nakedResponse := &CDROMOpenFTPResponseEnvelope{}
+	nakedResponse := &cdromOpenFTPResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -694,9 +694,9 @@ func (o *DiskOp) Find(ctx context.Context, zone string, conditions *FindConditio
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &DiskFindRequestEnvelope{}
+			body = &diskFindRequestEnvelope{}
 		}
-		v := body.(*DiskFindRequestEnvelope)
+		v := body.(*diskFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -708,7 +708,7 @@ func (o *DiskOp) Find(ctx context.Context, zone string, conditions *FindConditio
 		return nil, err
 	}
 
-	nakedResponse := &DiskFindResponseEnvelope{}
+	nakedResponse := &diskFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -744,9 +744,9 @@ func (o *DiskOp) Create(ctx context.Context, zone string, param *DiskCreateReque
 			param = &DiskCreateRequest{}
 		}
 		if body == nil {
-			body = &DiskCreateRequestEnvelope{}
+			body = &diskCreateRequestEnvelope{}
 		}
-		v := body.(*DiskCreateRequestEnvelope)
+		v := body.(*diskCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -760,7 +760,7 @@ func (o *DiskOp) Create(ctx context.Context, zone string, param *DiskCreateReque
 		return nil, err
 	}
 
-	nakedResponse := &DiskCreateResponseEnvelope{}
+	nakedResponse := &diskCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -793,9 +793,9 @@ func (o *DiskOp) CreateDistantly(ctx context.Context, zone string, createParam *
 			createParam = &DiskCreateRequest{}
 		}
 		if body == nil {
-			body = &DiskCreateDistantlyRequestEnvelope{}
+			body = &diskCreateDistantlyRequestEnvelope{}
 		}
-		v := body.(*DiskCreateDistantlyRequestEnvelope)
+		v := body.(*diskCreateDistantlyRequestEnvelope)
 		n, err := createParam.convertTo()
 		if err != nil {
 			return nil, err
@@ -806,9 +806,9 @@ func (o *DiskOp) CreateDistantly(ctx context.Context, zone string, createParam *
 
 	{
 		if body == nil {
-			body = &DiskCreateDistantlyRequestEnvelope{}
+			body = &diskCreateDistantlyRequestEnvelope{}
 		}
-		v := body.(*DiskCreateDistantlyRequestEnvelope)
+		v := body.(*diskCreateDistantlyRequestEnvelope)
 		v.DistantFrom = distantFrom
 		body = v
 	}
@@ -818,7 +818,7 @@ func (o *DiskOp) CreateDistantly(ctx context.Context, zone string, createParam *
 		return nil, err
 	}
 
-	nakedResponse := &DiskCreateDistantlyResponseEnvelope{}
+	nakedResponse := &diskCreateDistantlyResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -850,9 +850,9 @@ func (o *DiskOp) Config(ctx context.Context, zone string, id types.ID, edit *Dis
 			edit = &DiskEditRequest{}
 		}
 		if body == nil {
-			body = &DiskConfigRequestEnvelope{}
+			body = &diskConfigRequestEnvelope{}
 		}
-		v := body.(*DiskConfigRequestEnvelope)
+		v := body.(*diskConfigRequestEnvelope)
 		if err := mapconv.ConvertTo(edit, v); err != nil {
 			return err
 		}
@@ -889,9 +889,9 @@ func (o *DiskOp) CreateWithConfig(ctx context.Context, zone string, createParam 
 			createParam = &DiskCreateRequest{}
 		}
 		if body == nil {
-			body = &DiskCreateWithConfigRequestEnvelope{}
+			body = &diskCreateWithConfigRequestEnvelope{}
 		}
-		v := body.(*DiskCreateWithConfigRequestEnvelope)
+		v := body.(*diskCreateWithConfigRequestEnvelope)
 		n, err := createParam.convertTo()
 		if err != nil {
 			return nil, err
@@ -905,9 +905,9 @@ func (o *DiskOp) CreateWithConfig(ctx context.Context, zone string, createParam 
 			editParam = &DiskEditRequest{}
 		}
 		if body == nil {
-			body = &DiskCreateWithConfigRequestEnvelope{}
+			body = &diskCreateWithConfigRequestEnvelope{}
 		}
-		v := body.(*DiskCreateWithConfigRequestEnvelope)
+		v := body.(*diskCreateWithConfigRequestEnvelope)
 		n, err := editParam.convertTo()
 		if err != nil {
 			return nil, err
@@ -918,9 +918,9 @@ func (o *DiskOp) CreateWithConfig(ctx context.Context, zone string, createParam 
 
 	{
 		if body == nil {
-			body = &DiskCreateWithConfigRequestEnvelope{}
+			body = &diskCreateWithConfigRequestEnvelope{}
 		}
-		v := body.(*DiskCreateWithConfigRequestEnvelope)
+		v := body.(*diskCreateWithConfigRequestEnvelope)
 		v.BootAtAvailable = bootAtAvailable
 		body = v
 	}
@@ -930,7 +930,7 @@ func (o *DiskOp) CreateWithConfig(ctx context.Context, zone string, createParam 
 		return nil, err
 	}
 
-	nakedResponse := &DiskCreateWithConfigResponseEnvelope{}
+	nakedResponse := &diskCreateWithConfigResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -965,9 +965,9 @@ func (o *DiskOp) CreateWithConfigDistantly(ctx context.Context, zone string, cre
 			createParam = &DiskCreateRequest{}
 		}
 		if body == nil {
-			body = &DiskCreateWithConfigDistantlyRequestEnvelope{}
+			body = &diskCreateWithConfigDistantlyRequestEnvelope{}
 		}
-		v := body.(*DiskCreateWithConfigDistantlyRequestEnvelope)
+		v := body.(*diskCreateWithConfigDistantlyRequestEnvelope)
 		n, err := createParam.convertTo()
 		if err != nil {
 			return nil, err
@@ -981,9 +981,9 @@ func (o *DiskOp) CreateWithConfigDistantly(ctx context.Context, zone string, cre
 			editParam = &DiskEditRequest{}
 		}
 		if body == nil {
-			body = &DiskCreateWithConfigDistantlyRequestEnvelope{}
+			body = &diskCreateWithConfigDistantlyRequestEnvelope{}
 		}
-		v := body.(*DiskCreateWithConfigDistantlyRequestEnvelope)
+		v := body.(*diskCreateWithConfigDistantlyRequestEnvelope)
 		n, err := editParam.convertTo()
 		if err != nil {
 			return nil, err
@@ -994,18 +994,18 @@ func (o *DiskOp) CreateWithConfigDistantly(ctx context.Context, zone string, cre
 
 	{
 		if body == nil {
-			body = &DiskCreateWithConfigDistantlyRequestEnvelope{}
+			body = &diskCreateWithConfigDistantlyRequestEnvelope{}
 		}
-		v := body.(*DiskCreateWithConfigDistantlyRequestEnvelope)
+		v := body.(*diskCreateWithConfigDistantlyRequestEnvelope)
 		v.BootAtAvailable = bootAtAvailable
 		body = v
 	}
 
 	{
 		if body == nil {
-			body = &DiskCreateWithConfigDistantlyRequestEnvelope{}
+			body = &diskCreateWithConfigDistantlyRequestEnvelope{}
 		}
-		v := body.(*DiskCreateWithConfigDistantlyRequestEnvelope)
+		v := body.(*diskCreateWithConfigDistantlyRequestEnvelope)
 		v.DistantFrom = distantFrom
 		body = v
 	}
@@ -1015,7 +1015,7 @@ func (o *DiskOp) CreateWithConfigDistantly(ctx context.Context, zone string, cre
 		return nil, err
 	}
 
-	nakedResponse := &DiskCreateWithConfigDistantlyResponseEnvelope{}
+	nakedResponse := &diskCreateWithConfigDistantlyResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1142,9 +1142,9 @@ func (o *DiskOp) Install(ctx context.Context, zone string, id types.ID, installP
 			installParam = &DiskInstallRequest{}
 		}
 		if body == nil {
-			body = &DiskInstallRequestEnvelope{}
+			body = &diskInstallRequestEnvelope{}
 		}
-		v := body.(*DiskInstallRequestEnvelope)
+		v := body.(*diskInstallRequestEnvelope)
 		n, err := installParam.convertTo()
 		if err != nil {
 			return nil, err
@@ -1155,9 +1155,9 @@ func (o *DiskOp) Install(ctx context.Context, zone string, id types.ID, installP
 
 	{
 		if body == nil {
-			body = &DiskInstallRequestEnvelope{}
+			body = &diskInstallRequestEnvelope{}
 		}
-		v := body.(*DiskInstallRequestEnvelope)
+		v := body.(*diskInstallRequestEnvelope)
 		v.DistantFrom = distantFrom
 		body = v
 	}
@@ -1167,7 +1167,7 @@ func (o *DiskOp) Install(ctx context.Context, zone string, id types.ID, installP
 		return nil, err
 	}
 
-	nakedResponse := &DiskInstallResponseEnvelope{}
+	nakedResponse := &diskInstallResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1200,9 +1200,9 @@ func (o *DiskOp) InstallDistantFrom(ctx context.Context, zone string, id types.I
 			installParam = &DiskInstallRequest{}
 		}
 		if body == nil {
-			body = &DiskInstallDistantFromRequestEnvelope{}
+			body = &diskInstallDistantFromRequestEnvelope{}
 		}
-		v := body.(*DiskInstallDistantFromRequestEnvelope)
+		v := body.(*diskInstallDistantFromRequestEnvelope)
 		n, err := installParam.convertTo()
 		if err != nil {
 			return nil, err
@@ -1216,7 +1216,7 @@ func (o *DiskOp) InstallDistantFrom(ctx context.Context, zone string, id types.I
 		return nil, err
 	}
 
-	nakedResponse := &DiskInstallDistantFromResponseEnvelope{}
+	nakedResponse := &diskInstallDistantFromResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1248,7 +1248,7 @@ func (o *DiskOp) Read(ctx context.Context, zone string, id types.ID) (*Disk, err
 		return nil, err
 	}
 
-	nakedResponse := &DiskReadResponseEnvelope{}
+	nakedResponse := &diskReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1281,9 +1281,9 @@ func (o *DiskOp) Update(ctx context.Context, zone string, id types.ID, param *Di
 			param = &DiskUpdateRequest{}
 		}
 		if body == nil {
-			body = &DiskUpdateRequestEnvelope{}
+			body = &diskUpdateRequestEnvelope{}
 		}
-		v := body.(*DiskUpdateRequestEnvelope)
+		v := body.(*diskUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -1297,7 +1297,7 @@ func (o *DiskOp) Update(ctx context.Context, zone string, id types.ID, param *Di
 		return nil, err
 	}
 
-	nakedResponse := &DiskUpdateResponseEnvelope{}
+	nakedResponse := &diskUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1352,9 +1352,9 @@ func (o *DiskOp) Monitor(ctx context.Context, zone string, id types.ID, conditio
 			condition = &MonitorCondition{}
 		}
 		if body == nil {
-			body = &DiskMonitorRequestEnvelope{}
+			body = &diskMonitorRequestEnvelope{}
 		}
-		v := body.(*DiskMonitorRequestEnvelope)
+		v := body.(*diskMonitorRequestEnvelope)
 		if err := mapconv.ConvertTo(condition, v); err != nil {
 			return nil, err
 		}
@@ -1366,7 +1366,7 @@ func (o *DiskOp) Monitor(ctx context.Context, zone string, id types.ID, conditio
 		return nil, err
 	}
 
-	nakedResponse := &DiskMonitorResponseEnvelope{}
+	nakedResponse := &diskMonitorResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1420,9 +1420,9 @@ func (o *GSLBOp) Find(ctx context.Context, zone string, conditions *FindConditio
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &GSLBFindRequestEnvelope{}
+			body = &gslbFindRequestEnvelope{}
 		}
-		v := body.(*GSLBFindRequestEnvelope)
+		v := body.(*gslbFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -1434,7 +1434,7 @@ func (o *GSLBOp) Find(ctx context.Context, zone string, conditions *FindConditio
 		return nil, err
 	}
 
-	nakedResponse := &GSLBFindResponseEnvelope{}
+	nakedResponse := &gslbFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1470,9 +1470,9 @@ func (o *GSLBOp) Create(ctx context.Context, zone string, param *GSLBCreateReque
 			param = &GSLBCreateRequest{}
 		}
 		if body == nil {
-			body = &GSLBCreateRequestEnvelope{}
+			body = &gslbCreateRequestEnvelope{}
 		}
-		v := body.(*GSLBCreateRequestEnvelope)
+		v := body.(*gslbCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -1486,7 +1486,7 @@ func (o *GSLBOp) Create(ctx context.Context, zone string, param *GSLBCreateReque
 		return nil, err
 	}
 
-	nakedResponse := &GSLBCreateResponseEnvelope{}
+	nakedResponse := &gslbCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1518,7 +1518,7 @@ func (o *GSLBOp) Read(ctx context.Context, zone string, id types.ID) (*GSLB, err
 		return nil, err
 	}
 
-	nakedResponse := &GSLBReadResponseEnvelope{}
+	nakedResponse := &gslbReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1551,9 +1551,9 @@ func (o *GSLBOp) Update(ctx context.Context, zone string, id types.ID, param *GS
 			param = &GSLBUpdateRequest{}
 		}
 		if body == nil {
-			body = &GSLBUpdateRequestEnvelope{}
+			body = &gslbUpdateRequestEnvelope{}
 		}
-		v := body.(*GSLBUpdateRequestEnvelope)
+		v := body.(*gslbUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -1567,7 +1567,7 @@ func (o *GSLBOp) Update(ctx context.Context, zone string, id types.ID, param *GS
 		return nil, err
 	}
 
-	nakedResponse := &GSLBUpdateResponseEnvelope{}
+	nakedResponse := &gslbUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1644,9 +1644,9 @@ func (o *InterfaceOp) Find(ctx context.Context, zone string, conditions *FindCon
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &InterfaceFindRequestEnvelope{}
+			body = &interfaceFindRequestEnvelope{}
 		}
-		v := body.(*InterfaceFindRequestEnvelope)
+		v := body.(*interfaceFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -1658,7 +1658,7 @@ func (o *InterfaceOp) Find(ctx context.Context, zone string, conditions *FindCon
 		return nil, err
 	}
 
-	nakedResponse := &InterfaceFindResponseEnvelope{}
+	nakedResponse := &interfaceFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1694,9 +1694,9 @@ func (o *InterfaceOp) Create(ctx context.Context, zone string, param *InterfaceC
 			param = &InterfaceCreateRequest{}
 		}
 		if body == nil {
-			body = &InterfaceCreateRequestEnvelope{}
+			body = &interfaceCreateRequestEnvelope{}
 		}
-		v := body.(*InterfaceCreateRequestEnvelope)
+		v := body.(*interfaceCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -1710,7 +1710,7 @@ func (o *InterfaceOp) Create(ctx context.Context, zone string, param *InterfaceC
 		return nil, err
 	}
 
-	nakedResponse := &InterfaceCreateResponseEnvelope{}
+	nakedResponse := &interfaceCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1742,7 +1742,7 @@ func (o *InterfaceOp) Read(ctx context.Context, zone string, id types.ID) (*Inte
 		return nil, err
 	}
 
-	nakedResponse := &InterfaceReadResponseEnvelope{}
+	nakedResponse := &interfaceReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1775,9 +1775,9 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 			param = &InterfaceUpdateRequest{}
 		}
 		if body == nil {
-			body = &InterfaceUpdateRequestEnvelope{}
+			body = &interfaceUpdateRequestEnvelope{}
 		}
-		v := body.(*InterfaceUpdateRequestEnvelope)
+		v := body.(*interfaceUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -1791,7 +1791,7 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 		return nil, err
 	}
 
-	nakedResponse := &InterfaceUpdateResponseEnvelope{}
+	nakedResponse := &interfaceUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -1846,9 +1846,9 @@ func (o *InterfaceOp) Monitor(ctx context.Context, zone string, id types.ID, con
 			condition = &MonitorCondition{}
 		}
 		if body == nil {
-			body = &InterfaceMonitorRequestEnvelope{}
+			body = &interfaceMonitorRequestEnvelope{}
 		}
-		v := body.(*InterfaceMonitorRequestEnvelope)
+		v := body.(*interfaceMonitorRequestEnvelope)
 		if err := mapconv.ConvertTo(condition, v); err != nil {
 			return nil, err
 		}
@@ -1860,7 +1860,7 @@ func (o *InterfaceOp) Monitor(ctx context.Context, zone string, id types.ID, con
 		return nil, err
 	}
 
-	nakedResponse := &InterfaceMonitorResponseEnvelope{}
+	nakedResponse := &interfaceMonitorResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2031,9 +2031,9 @@ func (o *LoadBalancerOp) Find(ctx context.Context, zone string, conditions *Find
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &LoadBalancerFindRequestEnvelope{}
+			body = &loadbalancerFindRequestEnvelope{}
 		}
-		v := body.(*LoadBalancerFindRequestEnvelope)
+		v := body.(*loadbalancerFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -2045,7 +2045,7 @@ func (o *LoadBalancerOp) Find(ctx context.Context, zone string, conditions *Find
 		return nil, err
 	}
 
-	nakedResponse := &LoadBalancerFindResponseEnvelope{}
+	nakedResponse := &loadbalancerFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2081,9 +2081,9 @@ func (o *LoadBalancerOp) Create(ctx context.Context, zone string, param *LoadBal
 			param = &LoadBalancerCreateRequest{}
 		}
 		if body == nil {
-			body = &LoadBalancerCreateRequestEnvelope{}
+			body = &loadbalancerCreateRequestEnvelope{}
 		}
-		v := body.(*LoadBalancerCreateRequestEnvelope)
+		v := body.(*loadbalancerCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -2097,7 +2097,7 @@ func (o *LoadBalancerOp) Create(ctx context.Context, zone string, param *LoadBal
 		return nil, err
 	}
 
-	nakedResponse := &LoadBalancerCreateResponseEnvelope{}
+	nakedResponse := &loadbalancerCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2129,7 +2129,7 @@ func (o *LoadBalancerOp) Read(ctx context.Context, zone string, id types.ID) (*L
 		return nil, err
 	}
 
-	nakedResponse := &LoadBalancerReadResponseEnvelope{}
+	nakedResponse := &loadbalancerReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2162,9 +2162,9 @@ func (o *LoadBalancerOp) Update(ctx context.Context, zone string, id types.ID, p
 			param = &LoadBalancerUpdateRequest{}
 		}
 		if body == nil {
-			body = &LoadBalancerUpdateRequestEnvelope{}
+			body = &loadbalancerUpdateRequestEnvelope{}
 		}
-		v := body.(*LoadBalancerUpdateRequestEnvelope)
+		v := body.(*loadbalancerUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -2178,7 +2178,7 @@ func (o *LoadBalancerOp) Update(ctx context.Context, zone string, id types.ID, p
 		return nil, err
 	}
 
-	nakedResponse := &LoadBalancerUpdateResponseEnvelope{}
+	nakedResponse := &loadbalancerUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2279,9 +2279,9 @@ func (o *LoadBalancerOp) Shutdown(ctx context.Context, zone string, id types.ID,
 			shutdownOption = &ShutdownOption{}
 		}
 		if body == nil {
-			body = &LoadBalancerShutdownRequestEnvelope{}
+			body = &loadbalancerShutdownRequestEnvelope{}
 		}
-		v := body.(*LoadBalancerShutdownRequestEnvelope)
+		v := body.(*loadbalancerShutdownRequestEnvelope)
 		if err := mapconv.ConvertTo(shutdownOption, v); err != nil {
 			return err
 		}
@@ -2339,9 +2339,9 @@ func (o *LoadBalancerOp) MonitorInterface(ctx context.Context, zone string, id t
 			condition = &MonitorCondition{}
 		}
 		if body == nil {
-			body = &LoadBalancerMonitorInterfaceRequestEnvelope{}
+			body = &loadbalancerMonitorInterfaceRequestEnvelope{}
 		}
-		v := body.(*LoadBalancerMonitorInterfaceRequestEnvelope)
+		v := body.(*loadbalancerMonitorInterfaceRequestEnvelope)
 		if err := mapconv.ConvertTo(condition, v); err != nil {
 			return nil, err
 		}
@@ -2353,7 +2353,7 @@ func (o *LoadBalancerOp) MonitorInterface(ctx context.Context, zone string, id t
 		return nil, err
 	}
 
-	nakedResponse := &LoadBalancerMonitorInterfaceResponseEnvelope{}
+	nakedResponse := &loadbalancerMonitorInterfaceResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2385,7 +2385,7 @@ func (o *LoadBalancerOp) Status(ctx context.Context, zone string, id types.ID) (
 		return nil, err
 	}
 
-	nakedResponse := &LoadBalancerStatusResponseEnvelope{}
+	nakedResponse := &loadbalancerStatusResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2443,9 +2443,9 @@ func (o *NFSOp) Find(ctx context.Context, zone string, conditions *FindCondition
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &NFSFindRequestEnvelope{}
+			body = &nfsFindRequestEnvelope{}
 		}
-		v := body.(*NFSFindRequestEnvelope)
+		v := body.(*nfsFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -2457,7 +2457,7 @@ func (o *NFSOp) Find(ctx context.Context, zone string, conditions *FindCondition
 		return nil, err
 	}
 
-	nakedResponse := &NFSFindResponseEnvelope{}
+	nakedResponse := &nfsFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2493,9 +2493,9 @@ func (o *NFSOp) Create(ctx context.Context, zone string, param *NFSCreateRequest
 			param = &NFSCreateRequest{}
 		}
 		if body == nil {
-			body = &NFSCreateRequestEnvelope{}
+			body = &nfsCreateRequestEnvelope{}
 		}
-		v := body.(*NFSCreateRequestEnvelope)
+		v := body.(*nfsCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -2509,7 +2509,7 @@ func (o *NFSOp) Create(ctx context.Context, zone string, param *NFSCreateRequest
 		return nil, err
 	}
 
-	nakedResponse := &NFSCreateResponseEnvelope{}
+	nakedResponse := &nfsCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2541,7 +2541,7 @@ func (o *NFSOp) Read(ctx context.Context, zone string, id types.ID) (*NFS, error
 		return nil, err
 	}
 
-	nakedResponse := &NFSReadResponseEnvelope{}
+	nakedResponse := &nfsReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2574,9 +2574,9 @@ func (o *NFSOp) Update(ctx context.Context, zone string, id types.ID, param *NFS
 			param = &NFSUpdateRequest{}
 		}
 		if body == nil {
-			body = &NFSUpdateRequestEnvelope{}
+			body = &nfsUpdateRequestEnvelope{}
 		}
-		v := body.(*NFSUpdateRequestEnvelope)
+		v := body.(*nfsUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -2590,7 +2590,7 @@ func (o *NFSOp) Update(ctx context.Context, zone string, id types.ID, param *NFS
 		return nil, err
 	}
 
-	nakedResponse := &NFSUpdateResponseEnvelope{}
+	nakedResponse := &nfsUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2668,9 +2668,9 @@ func (o *NFSOp) Shutdown(ctx context.Context, zone string, id types.ID, shutdown
 			shutdownOption = &ShutdownOption{}
 		}
 		if body == nil {
-			body = &NFSShutdownRequestEnvelope{}
+			body = &nfsShutdownRequestEnvelope{}
 		}
-		v := body.(*NFSShutdownRequestEnvelope)
+		v := body.(*nfsShutdownRequestEnvelope)
 		if err := mapconv.ConvertTo(shutdownOption, v); err != nil {
 			return err
 		}
@@ -2728,9 +2728,9 @@ func (o *NFSOp) MonitorFreeDiskSize(ctx context.Context, zone string, id types.I
 			condition = &MonitorCondition{}
 		}
 		if body == nil {
-			body = &NFSMonitorFreeDiskSizeRequestEnvelope{}
+			body = &nfsMonitorFreeDiskSizeRequestEnvelope{}
 		}
-		v := body.(*NFSMonitorFreeDiskSizeRequestEnvelope)
+		v := body.(*nfsMonitorFreeDiskSizeRequestEnvelope)
 		if err := mapconv.ConvertTo(condition, v); err != nil {
 			return nil, err
 		}
@@ -2742,7 +2742,7 @@ func (o *NFSOp) MonitorFreeDiskSize(ctx context.Context, zone string, id types.I
 		return nil, err
 	}
 
-	nakedResponse := &NFSMonitorFreeDiskSizeResponseEnvelope{}
+	nakedResponse := &nfsMonitorFreeDiskSizeResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2774,9 +2774,9 @@ func (o *NFSOp) MonitorInterface(ctx context.Context, zone string, id types.ID, 
 			condition = &MonitorCondition{}
 		}
 		if body == nil {
-			body = &NFSMonitorInterfaceRequestEnvelope{}
+			body = &nfsMonitorInterfaceRequestEnvelope{}
 		}
-		v := body.(*NFSMonitorInterfaceRequestEnvelope)
+		v := body.(*nfsMonitorInterfaceRequestEnvelope)
 		if err := mapconv.ConvertTo(condition, v); err != nil {
 			return nil, err
 		}
@@ -2788,7 +2788,7 @@ func (o *NFSOp) MonitorInterface(ctx context.Context, zone string, id types.ID, 
 		return nil, err
 	}
 
-	nakedResponse := &NFSMonitorInterfaceResponseEnvelope{}
+	nakedResponse := &nfsMonitorInterfaceResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2842,9 +2842,9 @@ func (o *NoteOp) Find(ctx context.Context, zone string, conditions *FindConditio
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &NoteFindRequestEnvelope{}
+			body = &noteFindRequestEnvelope{}
 		}
-		v := body.(*NoteFindRequestEnvelope)
+		v := body.(*noteFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -2856,7 +2856,7 @@ func (o *NoteOp) Find(ctx context.Context, zone string, conditions *FindConditio
 		return nil, err
 	}
 
-	nakedResponse := &NoteFindResponseEnvelope{}
+	nakedResponse := &noteFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2892,9 +2892,9 @@ func (o *NoteOp) Create(ctx context.Context, zone string, param *NoteCreateReque
 			param = &NoteCreateRequest{}
 		}
 		if body == nil {
-			body = &NoteCreateRequestEnvelope{}
+			body = &noteCreateRequestEnvelope{}
 		}
-		v := body.(*NoteCreateRequestEnvelope)
+		v := body.(*noteCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -2908,7 +2908,7 @@ func (o *NoteOp) Create(ctx context.Context, zone string, param *NoteCreateReque
 		return nil, err
 	}
 
-	nakedResponse := &NoteCreateResponseEnvelope{}
+	nakedResponse := &noteCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2940,7 +2940,7 @@ func (o *NoteOp) Read(ctx context.Context, zone string, id types.ID) (*Note, err
 		return nil, err
 	}
 
-	nakedResponse := &NoteReadResponseEnvelope{}
+	nakedResponse := &noteReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -2973,9 +2973,9 @@ func (o *NoteOp) Update(ctx context.Context, zone string, id types.ID, param *No
 			param = &NoteUpdateRequest{}
 		}
 		if body == nil {
-			body = &NoteUpdateRequestEnvelope{}
+			body = &noteUpdateRequestEnvelope{}
 		}
-		v := body.(*NoteUpdateRequestEnvelope)
+		v := body.(*noteUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -2989,7 +2989,7 @@ func (o *NoteOp) Update(ctx context.Context, zone string, id types.ID, param *No
 		return nil, err
 	}
 
-	nakedResponse := &NoteUpdateResponseEnvelope{}
+	nakedResponse := &noteUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3066,9 +3066,9 @@ func (o *ServerOp) Find(ctx context.Context, zone string, conditions *FindCondit
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &ServerFindRequestEnvelope{}
+			body = &serverFindRequestEnvelope{}
 		}
-		v := body.(*ServerFindRequestEnvelope)
+		v := body.(*serverFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -3080,7 +3080,7 @@ func (o *ServerOp) Find(ctx context.Context, zone string, conditions *FindCondit
 		return nil, err
 	}
 
-	nakedResponse := &ServerFindResponseEnvelope{}
+	nakedResponse := &serverFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3116,9 +3116,9 @@ func (o *ServerOp) Create(ctx context.Context, zone string, param *ServerCreateR
 			param = &ServerCreateRequest{}
 		}
 		if body == nil {
-			body = &ServerCreateRequestEnvelope{}
+			body = &serverCreateRequestEnvelope{}
 		}
-		v := body.(*ServerCreateRequestEnvelope)
+		v := body.(*serverCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -3132,7 +3132,7 @@ func (o *ServerOp) Create(ctx context.Context, zone string, param *ServerCreateR
 		return nil, err
 	}
 
-	nakedResponse := &ServerCreateResponseEnvelope{}
+	nakedResponse := &serverCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3164,7 +3164,7 @@ func (o *ServerOp) Read(ctx context.Context, zone string, id types.ID) (*Server,
 		return nil, err
 	}
 
-	nakedResponse := &ServerReadResponseEnvelope{}
+	nakedResponse := &serverReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3197,9 +3197,9 @@ func (o *ServerOp) Update(ctx context.Context, zone string, id types.ID, param *
 			param = &ServerUpdateRequest{}
 		}
 		if body == nil {
-			body = &ServerUpdateRequestEnvelope{}
+			body = &serverUpdateRequestEnvelope{}
 		}
-		v := body.(*ServerUpdateRequestEnvelope)
+		v := body.(*serverUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -3213,7 +3213,7 @@ func (o *ServerOp) Update(ctx context.Context, zone string, id types.ID, param *
 		return nil, err
 	}
 
-	nakedResponse := &ServerUpdateResponseEnvelope{}
+	nakedResponse := &serverUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3268,9 +3268,9 @@ func (o *ServerOp) ChangePlan(ctx context.Context, zone string, id types.ID, pla
 			plan = &ServerChangePlanRequest{}
 		}
 		if body == nil {
-			body = &ServerChangePlanRequestEnvelope{}
+			body = &serverChangePlanRequestEnvelope{}
 		}
-		v := body.(*ServerChangePlanRequestEnvelope)
+		v := body.(*serverChangePlanRequestEnvelope)
 		if err := mapconv.ConvertTo(plan, v); err != nil {
 			return nil, err
 		}
@@ -3282,7 +3282,7 @@ func (o *ServerOp) ChangePlan(ctx context.Context, zone string, id types.ID, pla
 		return nil, err
 	}
 
-	nakedResponse := &ServerChangePlanResponseEnvelope{}
+	nakedResponse := &serverChangePlanResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3315,9 +3315,9 @@ func (o *ServerOp) InsertCDROM(ctx context.Context, zone string, id types.ID, in
 			insertParam = &InsertCDROMRequest{}
 		}
 		if body == nil {
-			body = &ServerInsertCDROMRequestEnvelope{}
+			body = &serverInsertCDROMRequestEnvelope{}
 		}
-		v := body.(*ServerInsertCDROMRequestEnvelope)
+		v := body.(*serverInsertCDROMRequestEnvelope)
 		n, err := insertParam.convertTo()
 		if err != nil {
 			return err
@@ -3355,9 +3355,9 @@ func (o *ServerOp) EjectCDROM(ctx context.Context, zone string, id types.ID, ins
 			insertParam = &EjectCDROMRequest{}
 		}
 		if body == nil {
-			body = &ServerEjectCDROMRequestEnvelope{}
+			body = &serverEjectCDROMRequestEnvelope{}
 		}
-		v := body.(*ServerEjectCDROMRequestEnvelope)
+		v := body.(*serverEjectCDROMRequestEnvelope)
 		n, err := insertParam.convertTo()
 		if err != nil {
 			return err
@@ -3417,9 +3417,9 @@ func (o *ServerOp) Shutdown(ctx context.Context, zone string, id types.ID, shutd
 			shutdownOption = &ShutdownOption{}
 		}
 		if body == nil {
-			body = &ServerShutdownRequestEnvelope{}
+			body = &serverShutdownRequestEnvelope{}
 		}
-		v := body.(*ServerShutdownRequestEnvelope)
+		v := body.(*serverShutdownRequestEnvelope)
 		if err := mapconv.ConvertTo(shutdownOption, v); err != nil {
 			return err
 		}
@@ -3477,9 +3477,9 @@ func (o *ServerOp) Monitor(ctx context.Context, zone string, id types.ID, condit
 			condition = &MonitorCondition{}
 		}
 		if body == nil {
-			body = &ServerMonitorRequestEnvelope{}
+			body = &serverMonitorRequestEnvelope{}
 		}
-		v := body.(*ServerMonitorRequestEnvelope)
+		v := body.(*serverMonitorRequestEnvelope)
 		if err := mapconv.ConvertTo(condition, v); err != nil {
 			return nil, err
 		}
@@ -3491,7 +3491,7 @@ func (o *ServerOp) Monitor(ctx context.Context, zone string, id types.ID, condit
 		return nil, err
 	}
 
-	nakedResponse := &ServerMonitorResponseEnvelope{}
+	nakedResponse := &serverMonitorResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3545,9 +3545,9 @@ func (o *SwitchOp) Find(ctx context.Context, zone string, conditions *FindCondit
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &SwitchFindRequestEnvelope{}
+			body = &switchFindRequestEnvelope{}
 		}
-		v := body.(*SwitchFindRequestEnvelope)
+		v := body.(*switchFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -3559,7 +3559,7 @@ func (o *SwitchOp) Find(ctx context.Context, zone string, conditions *FindCondit
 		return nil, err
 	}
 
-	nakedResponse := &SwitchFindResponseEnvelope{}
+	nakedResponse := &switchFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3595,9 +3595,9 @@ func (o *SwitchOp) Create(ctx context.Context, zone string, param *SwitchCreateR
 			param = &SwitchCreateRequest{}
 		}
 		if body == nil {
-			body = &SwitchCreateRequestEnvelope{}
+			body = &switchCreateRequestEnvelope{}
 		}
-		v := body.(*SwitchCreateRequestEnvelope)
+		v := body.(*switchCreateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -3611,7 +3611,7 @@ func (o *SwitchOp) Create(ctx context.Context, zone string, param *SwitchCreateR
 		return nil, err
 	}
 
-	nakedResponse := &SwitchCreateResponseEnvelope{}
+	nakedResponse := &switchCreateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3643,7 +3643,7 @@ func (o *SwitchOp) Read(ctx context.Context, zone string, id types.ID) (*Switch,
 		return nil, err
 	}
 
-	nakedResponse := &SwitchReadResponseEnvelope{}
+	nakedResponse := &switchReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3676,9 +3676,9 @@ func (o *SwitchOp) Update(ctx context.Context, zone string, id types.ID, param *
 			param = &SwitchUpdateRequest{}
 		}
 		if body == nil {
-			body = &SwitchUpdateRequestEnvelope{}
+			body = &switchUpdateRequestEnvelope{}
 		}
-		v := body.(*SwitchUpdateRequestEnvelope)
+		v := body.(*switchUpdateRequestEnvelope)
 		n, err := param.convertTo()
 		if err != nil {
 			return nil, err
@@ -3692,7 +3692,7 @@ func (o *SwitchOp) Update(ctx context.Context, zone string, id types.ID, param *
 		return nil, err
 	}
 
-	nakedResponse := &SwitchUpdateResponseEnvelope{}
+	nakedResponse := &switchUpdateResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3816,9 +3816,9 @@ func (o *ZoneOp) Find(ctx context.Context, zone string, conditions *FindConditio
 			conditions = &FindCondition{}
 		}
 		if body == nil {
-			body = &ZoneFindRequestEnvelope{}
+			body = &zoneFindRequestEnvelope{}
 		}
-		v := body.(*ZoneFindRequestEnvelope)
+		v := body.(*zoneFindRequestEnvelope)
 		if err := mapconv.ConvertTo(conditions, v); err != nil {
 			return nil, err
 		}
@@ -3830,7 +3830,7 @@ func (o *ZoneOp) Find(ctx context.Context, zone string, conditions *FindConditio
 		return nil, err
 	}
 
-	nakedResponse := &ZoneFindResponseEnvelope{}
+	nakedResponse := &zoneFindResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}
@@ -3866,7 +3866,7 @@ func (o *ZoneOp) Read(ctx context.Context, zone string, id types.ID) (*Zone, err
 		return nil, err
 	}
 
-	nakedResponse := &ZoneReadResponseEnvelope{}
+	nakedResponse := &zoneReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -9,8 +9,8 @@ import (
 	"github.com/sacloud/libsacloud-v2/sacloud/types"
 )
 
-// ArchiveFindRequestEnvelope is envelop of API request
-type ArchiveFindRequestEnvelope struct {
+// archiveFindRequestEnvelope is envelop of API request
+type archiveFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -19,8 +19,8 @@ type ArchiveFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// ArchiveFindResponseEnvelope is envelop of API response
-type ArchiveFindResponseEnvelope struct {
+// archiveFindResponseEnvelope is envelop of API response
+type archiveFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -28,26 +28,26 @@ type ArchiveFindResponseEnvelope struct {
 	Archives []*naked.Archive `json:",omitempty"`
 }
 
-// ArchiveCreateRequestEnvelope is envelop of API request
-type ArchiveCreateRequestEnvelope struct {
+// archiveCreateRequestEnvelope is envelop of API request
+type archiveCreateRequestEnvelope struct {
 	Archive *naked.Archive `json:",omitempty"`
 }
 
-// ArchiveCreateResponseEnvelope is envelop of API response
-type ArchiveCreateResponseEnvelope struct {
+// archiveCreateResponseEnvelope is envelop of API response
+type archiveCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Archive *naked.Archive `json:",omitempty"`
 }
 
-// ArchiveCreateBlankRequestEnvelope is envelop of API request
-type ArchiveCreateBlankRequestEnvelope struct {
+// archiveCreateBlankRequestEnvelope is envelop of API request
+type archiveCreateBlankRequestEnvelope struct {
 	Archive *naked.Archive `json:",omitempty"`
 }
 
-// ArchiveCreateBlankResponseEnvelope is envelop of API response
-type ArchiveCreateBlankResponseEnvelope struct {
+// archiveCreateBlankResponseEnvelope is envelop of API response
+type archiveCreateBlankResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -55,42 +55,42 @@ type ArchiveCreateBlankResponseEnvelope struct {
 	FTPServer *naked.OpeningFTPServer `json:",omitempty"`
 }
 
-// ArchiveReadResponseEnvelope is envelop of API response
-type ArchiveReadResponseEnvelope struct {
+// archiveReadResponseEnvelope is envelop of API response
+type archiveReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Archive *naked.Archive `json:",omitempty"`
 }
 
-// ArchiveUpdateRequestEnvelope is envelop of API request
-type ArchiveUpdateRequestEnvelope struct {
+// archiveUpdateRequestEnvelope is envelop of API request
+type archiveUpdateRequestEnvelope struct {
 	Archive *naked.Archive `json:",omitempty"`
 }
 
-// ArchiveUpdateResponseEnvelope is envelop of API response
-type ArchiveUpdateResponseEnvelope struct {
+// archiveUpdateResponseEnvelope is envelop of API response
+type archiveUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Archive *naked.Archive `json:",omitempty"`
 }
 
-// ArchiveOpenFTPRequestEnvelope is envelop of API request
-type ArchiveOpenFTPRequestEnvelope struct {
+// archiveOpenFTPRequestEnvelope is envelop of API request
+type archiveOpenFTPRequestEnvelope struct {
 	ChangePassword bool `json:",omitempty"`
 }
 
-// ArchiveOpenFTPResponseEnvelope is envelop of API response
-type ArchiveOpenFTPResponseEnvelope struct {
+// archiveOpenFTPResponseEnvelope is envelop of API response
+type archiveOpenFTPResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	FTPServer *naked.OpeningFTPServer `json:",omitempty"`
 }
 
-// CDROMFindRequestEnvelope is envelop of API request
-type CDROMFindRequestEnvelope struct {
+// cdromFindRequestEnvelope is envelop of API request
+type cdromFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -99,8 +99,8 @@ type CDROMFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// CDROMFindResponseEnvelope is envelop of API response
-type CDROMFindResponseEnvelope struct {
+// cdromFindResponseEnvelope is envelop of API response
+type cdromFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -108,13 +108,13 @@ type CDROMFindResponseEnvelope struct {
 	CDROMs []*naked.CDROM `json:",omitempty"`
 }
 
-// CDROMCreateRequestEnvelope is envelop of API request
-type CDROMCreateRequestEnvelope struct {
+// cdromCreateRequestEnvelope is envelop of API request
+type cdromCreateRequestEnvelope struct {
 	CDROM *naked.CDROM `json:",omitempty"`
 }
 
-// CDROMCreateResponseEnvelope is envelop of API response
-type CDROMCreateResponseEnvelope struct {
+// cdromCreateResponseEnvelope is envelop of API response
+type cdromCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -122,42 +122,42 @@ type CDROMCreateResponseEnvelope struct {
 	FTPServer *naked.OpeningFTPServer `json:",omitempty"`
 }
 
-// CDROMReadResponseEnvelope is envelop of API response
-type CDROMReadResponseEnvelope struct {
+// cdromReadResponseEnvelope is envelop of API response
+type cdromReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	CDROM *naked.CDROM `json:",omitempty"`
 }
 
-// CDROMUpdateRequestEnvelope is envelop of API request
-type CDROMUpdateRequestEnvelope struct {
+// cdromUpdateRequestEnvelope is envelop of API request
+type cdromUpdateRequestEnvelope struct {
 	CDROM *naked.CDROM `json:",omitempty"`
 }
 
-// CDROMUpdateResponseEnvelope is envelop of API response
-type CDROMUpdateResponseEnvelope struct {
+// cdromUpdateResponseEnvelope is envelop of API response
+type cdromUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	CDROM *naked.CDROM `json:",omitempty"`
 }
 
-// CDROMOpenFTPRequestEnvelope is envelop of API request
-type CDROMOpenFTPRequestEnvelope struct {
+// cdromOpenFTPRequestEnvelope is envelop of API request
+type cdromOpenFTPRequestEnvelope struct {
 	ChangePassword bool `json:",omitempty"`
 }
 
-// CDROMOpenFTPResponseEnvelope is envelop of API response
-type CDROMOpenFTPResponseEnvelope struct {
+// cdromOpenFTPResponseEnvelope is envelop of API response
+type cdromOpenFTPResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	FTPServer *naked.OpeningFTPServer `json:",omitempty"`
 }
 
-// DiskFindRequestEnvelope is envelop of API request
-type DiskFindRequestEnvelope struct {
+// diskFindRequestEnvelope is envelop of API request
+type diskFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -166,8 +166,8 @@ type DiskFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// DiskFindResponseEnvelope is envelop of API response
-type DiskFindResponseEnvelope struct {
+// diskFindResponseEnvelope is envelop of API response
+type diskFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -175,35 +175,35 @@ type DiskFindResponseEnvelope struct {
 	Disks []*naked.Disk `json:",omitempty"`
 }
 
-// DiskCreateRequestEnvelope is envelop of API request
-type DiskCreateRequestEnvelope struct {
+// diskCreateRequestEnvelope is envelop of API request
+type diskCreateRequestEnvelope struct {
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskCreateResponseEnvelope is envelop of API response
-type DiskCreateResponseEnvelope struct {
+// diskCreateResponseEnvelope is envelop of API response
+type diskCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskCreateDistantlyRequestEnvelope is envelop of API request
-type DiskCreateDistantlyRequestEnvelope struct {
+// diskCreateDistantlyRequestEnvelope is envelop of API request
+type diskCreateDistantlyRequestEnvelope struct {
 	Disk        *naked.Disk `json:",omitempty"`
 	DistantFrom []types.ID  `json:",omitempty"`
 }
 
-// DiskCreateDistantlyResponseEnvelope is envelop of API response
-type DiskCreateDistantlyResponseEnvelope struct {
+// diskCreateDistantlyResponseEnvelope is envelop of API response
+type diskCreateDistantlyResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskConfigRequestEnvelope is envelop of API request
-type DiskConfigRequestEnvelope struct {
+// diskConfigRequestEnvelope is envelop of API request
+type diskConfigRequestEnvelope struct {
 	Password            string              `json:",omitempty"`
 	SSHKey              *DiskEditSSHKey     `json:",omitempty"`
 	SSHKeys             []*DiskEditSSHKey   `json:",omitempty"`
@@ -216,101 +216,101 @@ type DiskConfigRequestEnvelope struct {
 	UserSubnet          *DiskEditUserSubnet `json:",omitempty"`
 }
 
-// DiskCreateWithConfigRequestEnvelope is envelop of API request
-type DiskCreateWithConfigRequestEnvelope struct {
+// diskCreateWithConfigRequestEnvelope is envelop of API request
+type diskCreateWithConfigRequestEnvelope struct {
 	Disk            *naked.Disk     `json:",omitempty"`
 	Config          *naked.DiskEdit `json:",omitempty"`
 	BootAtAvailable bool            `json:",omitempty"`
 }
 
-// DiskCreateWithConfigResponseEnvelope is envelop of API response
-type DiskCreateWithConfigResponseEnvelope struct {
+// diskCreateWithConfigResponseEnvelope is envelop of API response
+type diskCreateWithConfigResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskCreateWithConfigDistantlyRequestEnvelope is envelop of API request
-type DiskCreateWithConfigDistantlyRequestEnvelope struct {
+// diskCreateWithConfigDistantlyRequestEnvelope is envelop of API request
+type diskCreateWithConfigDistantlyRequestEnvelope struct {
 	Disk            *naked.Disk     `json:",omitempty"`
 	Config          *naked.DiskEdit `json:",omitempty"`
 	BootAtAvailable bool            `json:",omitempty"`
 	DistantFrom     []types.ID      `json:",omitempty"`
 }
 
-// DiskCreateWithConfigDistantlyResponseEnvelope is envelop of API response
-type DiskCreateWithConfigDistantlyResponseEnvelope struct {
+// diskCreateWithConfigDistantlyResponseEnvelope is envelop of API response
+type diskCreateWithConfigDistantlyResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskInstallRequestEnvelope is envelop of API request
-type DiskInstallRequestEnvelope struct {
+// diskInstallRequestEnvelope is envelop of API request
+type diskInstallRequestEnvelope struct {
 	Disk        *naked.Disk `json:",omitempty"`
 	DistantFrom []types.ID  `json:",omitempty"`
 }
 
-// DiskInstallResponseEnvelope is envelop of API response
-type DiskInstallResponseEnvelope struct {
+// diskInstallResponseEnvelope is envelop of API response
+type diskInstallResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskInstallDistantFromRequestEnvelope is envelop of API request
-type DiskInstallDistantFromRequestEnvelope struct {
+// diskInstallDistantFromRequestEnvelope is envelop of API request
+type diskInstallDistantFromRequestEnvelope struct {
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskInstallDistantFromResponseEnvelope is envelop of API response
-type DiskInstallDistantFromResponseEnvelope struct {
+// diskInstallDistantFromResponseEnvelope is envelop of API response
+type diskInstallDistantFromResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskReadResponseEnvelope is envelop of API response
-type DiskReadResponseEnvelope struct {
+// diskReadResponseEnvelope is envelop of API response
+type diskReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskUpdateRequestEnvelope is envelop of API request
-type DiskUpdateRequestEnvelope struct {
+// diskUpdateRequestEnvelope is envelop of API request
+type diskUpdateRequestEnvelope struct {
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskUpdateResponseEnvelope is envelop of API response
-type DiskUpdateResponseEnvelope struct {
+// diskUpdateResponseEnvelope is envelop of API response
+type diskUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Disk *naked.Disk `json:",omitempty"`
 }
 
-// DiskMonitorRequestEnvelope is envelop of API request
-type DiskMonitorRequestEnvelope struct {
+// diskMonitorRequestEnvelope is envelop of API request
+type diskMonitorRequestEnvelope struct {
 	Start *time.Time `json:",omitempty"`
 	End   *time.Time `json:",omitempty"`
 }
 
-// DiskMonitorResponseEnvelope is envelop of API response
-type DiskMonitorResponseEnvelope struct {
+// diskMonitorResponseEnvelope is envelop of API response
+type diskMonitorResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Data *naked.MonitorValues `json:",omitempty"`
 }
 
-// GSLBFindRequestEnvelope is envelop of API request
-type GSLBFindRequestEnvelope struct {
+// gslbFindRequestEnvelope is envelop of API request
+type gslbFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -319,8 +319,8 @@ type GSLBFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// GSLBFindResponseEnvelope is envelop of API response
-type GSLBFindResponseEnvelope struct {
+// gslbFindResponseEnvelope is envelop of API response
+type gslbFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -328,42 +328,42 @@ type GSLBFindResponseEnvelope struct {
 	CommonServiceItems []*naked.GSLB `json:",omitempty"`
 }
 
-// GSLBCreateRequestEnvelope is envelop of API request
-type GSLBCreateRequestEnvelope struct {
+// gslbCreateRequestEnvelope is envelop of API request
+type gslbCreateRequestEnvelope struct {
 	CommonServiceItem *naked.GSLB `json:",omitempty"`
 }
 
-// GSLBCreateResponseEnvelope is envelop of API response
-type GSLBCreateResponseEnvelope struct {
+// gslbCreateResponseEnvelope is envelop of API response
+type gslbCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	CommonServiceItem *naked.GSLB `json:",omitempty"`
 }
 
-// GSLBReadResponseEnvelope is envelop of API response
-type GSLBReadResponseEnvelope struct {
+// gslbReadResponseEnvelope is envelop of API response
+type gslbReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	CommonServiceItem *naked.GSLB `json:",omitempty"`
 }
 
-// GSLBUpdateRequestEnvelope is envelop of API request
-type GSLBUpdateRequestEnvelope struct {
+// gslbUpdateRequestEnvelope is envelop of API request
+type gslbUpdateRequestEnvelope struct {
 	CommonServiceItem *naked.GSLB `json:",omitempty"`
 }
 
-// GSLBUpdateResponseEnvelope is envelop of API response
-type GSLBUpdateResponseEnvelope struct {
+// gslbUpdateResponseEnvelope is envelop of API response
+type gslbUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	CommonServiceItem *naked.GSLB `json:",omitempty"`
 }
 
-// InterfaceFindRequestEnvelope is envelop of API request
-type InterfaceFindRequestEnvelope struct {
+// interfaceFindRequestEnvelope is envelop of API request
+type interfaceFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -372,8 +372,8 @@ type InterfaceFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// InterfaceFindResponseEnvelope is envelop of API response
-type InterfaceFindResponseEnvelope struct {
+// interfaceFindResponseEnvelope is envelop of API response
+type interfaceFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -381,56 +381,56 @@ type InterfaceFindResponseEnvelope struct {
 	Interfaces []*naked.Interface `json:",omitempty"`
 }
 
-// InterfaceCreateRequestEnvelope is envelop of API request
-type InterfaceCreateRequestEnvelope struct {
+// interfaceCreateRequestEnvelope is envelop of API request
+type interfaceCreateRequestEnvelope struct {
 	Interface *naked.Interface `json:",omitempty"`
 }
 
-// InterfaceCreateResponseEnvelope is envelop of API response
-type InterfaceCreateResponseEnvelope struct {
+// interfaceCreateResponseEnvelope is envelop of API response
+type interfaceCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Interface *naked.Interface `json:",omitempty"`
 }
 
-// InterfaceReadResponseEnvelope is envelop of API response
-type InterfaceReadResponseEnvelope struct {
+// interfaceReadResponseEnvelope is envelop of API response
+type interfaceReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Interface *naked.Interface `json:",omitempty"`
 }
 
-// InterfaceUpdateRequestEnvelope is envelop of API request
-type InterfaceUpdateRequestEnvelope struct {
+// interfaceUpdateRequestEnvelope is envelop of API request
+type interfaceUpdateRequestEnvelope struct {
 	Interface *naked.Interface `json:",omitempty"`
 }
 
-// InterfaceUpdateResponseEnvelope is envelop of API response
-type InterfaceUpdateResponseEnvelope struct {
+// interfaceUpdateResponseEnvelope is envelop of API response
+type interfaceUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Interface *naked.Interface `json:",omitempty"`
 }
 
-// InterfaceMonitorRequestEnvelope is envelop of API request
-type InterfaceMonitorRequestEnvelope struct {
+// interfaceMonitorRequestEnvelope is envelop of API request
+type interfaceMonitorRequestEnvelope struct {
 	Start *time.Time `json:",omitempty"`
 	End   *time.Time `json:",omitempty"`
 }
 
-// InterfaceMonitorResponseEnvelope is envelop of API response
-type InterfaceMonitorResponseEnvelope struct {
+// interfaceMonitorResponseEnvelope is envelop of API response
+type interfaceMonitorResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Data *naked.MonitorValues `json:",omitempty"`
 }
 
-// LoadBalancerFindRequestEnvelope is envelop of API request
-type LoadBalancerFindRequestEnvelope struct {
+// loadbalancerFindRequestEnvelope is envelop of API request
+type loadbalancerFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -439,8 +439,8 @@ type LoadBalancerFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// LoadBalancerFindResponseEnvelope is envelop of API response
-type LoadBalancerFindResponseEnvelope struct {
+// loadbalancerFindResponseEnvelope is envelop of API response
+type loadbalancerFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -448,61 +448,61 @@ type LoadBalancerFindResponseEnvelope struct {
 	Appliances []*naked.LoadBalancer `json:",omitempty"`
 }
 
-// LoadBalancerCreateRequestEnvelope is envelop of API request
-type LoadBalancerCreateRequestEnvelope struct {
+// loadbalancerCreateRequestEnvelope is envelop of API request
+type loadbalancerCreateRequestEnvelope struct {
 	Appliance *naked.LoadBalancer `json:",omitempty"`
 }
 
-// LoadBalancerCreateResponseEnvelope is envelop of API response
-type LoadBalancerCreateResponseEnvelope struct {
+// loadbalancerCreateResponseEnvelope is envelop of API response
+type loadbalancerCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Appliance *naked.LoadBalancer `json:",omitempty"`
 }
 
-// LoadBalancerReadResponseEnvelope is envelop of API response
-type LoadBalancerReadResponseEnvelope struct {
+// loadbalancerReadResponseEnvelope is envelop of API response
+type loadbalancerReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Appliance *naked.LoadBalancer `json:",omitempty"`
 }
 
-// LoadBalancerUpdateRequestEnvelope is envelop of API request
-type LoadBalancerUpdateRequestEnvelope struct {
+// loadbalancerUpdateRequestEnvelope is envelop of API request
+type loadbalancerUpdateRequestEnvelope struct {
 	Appliance *naked.LoadBalancer `json:",omitempty"`
 }
 
-// LoadBalancerUpdateResponseEnvelope is envelop of API response
-type LoadBalancerUpdateResponseEnvelope struct {
+// loadbalancerUpdateResponseEnvelope is envelop of API response
+type loadbalancerUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Appliance *naked.LoadBalancer `json:",omitempty"`
 }
 
-// LoadBalancerShutdownRequestEnvelope is envelop of API request
-type LoadBalancerShutdownRequestEnvelope struct {
+// loadbalancerShutdownRequestEnvelope is envelop of API request
+type loadbalancerShutdownRequestEnvelope struct {
 	Force bool `json:",omitempty"`
 }
 
-// LoadBalancerMonitorInterfaceRequestEnvelope is envelop of API request
-type LoadBalancerMonitorInterfaceRequestEnvelope struct {
+// loadbalancerMonitorInterfaceRequestEnvelope is envelop of API request
+type loadbalancerMonitorInterfaceRequestEnvelope struct {
 	Start *time.Time `json:",omitempty"`
 	End   *time.Time `json:",omitempty"`
 }
 
-// LoadBalancerMonitorInterfaceResponseEnvelope is envelop of API response
-type LoadBalancerMonitorInterfaceResponseEnvelope struct {
+// loadbalancerMonitorInterfaceResponseEnvelope is envelop of API response
+type loadbalancerMonitorInterfaceResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Data *naked.MonitorValues `json:",omitempty"`
 }
 
-// LoadBalancerStatusResponseEnvelope is envelop of API response
-type LoadBalancerStatusResponseEnvelope struct {
+// loadbalancerStatusResponseEnvelope is envelop of API response
+type loadbalancerStatusResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -510,8 +510,8 @@ type LoadBalancerStatusResponseEnvelope struct {
 	LoadBalancer []*naked.LoadBalancerStatus `json:",omitempty"`
 }
 
-// NFSFindRequestEnvelope is envelop of API request
-type NFSFindRequestEnvelope struct {
+// nfsFindRequestEnvelope is envelop of API request
+type nfsFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -520,8 +520,8 @@ type NFSFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// NFSFindResponseEnvelope is envelop of API response
-type NFSFindResponseEnvelope struct {
+// nfsFindResponseEnvelope is envelop of API response
+type nfsFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -529,75 +529,75 @@ type NFSFindResponseEnvelope struct {
 	Appliances []*naked.NFS `json:",omitempty"`
 }
 
-// NFSCreateRequestEnvelope is envelop of API request
-type NFSCreateRequestEnvelope struct {
+// nfsCreateRequestEnvelope is envelop of API request
+type nfsCreateRequestEnvelope struct {
 	Appliance *naked.NFS `json:",omitempty"`
 }
 
-// NFSCreateResponseEnvelope is envelop of API response
-type NFSCreateResponseEnvelope struct {
+// nfsCreateResponseEnvelope is envelop of API response
+type nfsCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Appliance *naked.NFS `json:",omitempty"`
 }
 
-// NFSReadResponseEnvelope is envelop of API response
-type NFSReadResponseEnvelope struct {
+// nfsReadResponseEnvelope is envelop of API response
+type nfsReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Appliance *naked.NFS `json:",omitempty"`
 }
 
-// NFSUpdateRequestEnvelope is envelop of API request
-type NFSUpdateRequestEnvelope struct {
+// nfsUpdateRequestEnvelope is envelop of API request
+type nfsUpdateRequestEnvelope struct {
 	Appliance *naked.NFS `json:",omitempty"`
 }
 
-// NFSUpdateResponseEnvelope is envelop of API response
-type NFSUpdateResponseEnvelope struct {
+// nfsUpdateResponseEnvelope is envelop of API response
+type nfsUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Appliance *naked.NFS `json:",omitempty"`
 }
 
-// NFSShutdownRequestEnvelope is envelop of API request
-type NFSShutdownRequestEnvelope struct {
+// nfsShutdownRequestEnvelope is envelop of API request
+type nfsShutdownRequestEnvelope struct {
 	Force bool `json:",omitempty"`
 }
 
-// NFSMonitorFreeDiskSizeRequestEnvelope is envelop of API request
-type NFSMonitorFreeDiskSizeRequestEnvelope struct {
+// nfsMonitorFreeDiskSizeRequestEnvelope is envelop of API request
+type nfsMonitorFreeDiskSizeRequestEnvelope struct {
 	Start *time.Time `json:",omitempty"`
 	End   *time.Time `json:",omitempty"`
 }
 
-// NFSMonitorFreeDiskSizeResponseEnvelope is envelop of API response
-type NFSMonitorFreeDiskSizeResponseEnvelope struct {
+// nfsMonitorFreeDiskSizeResponseEnvelope is envelop of API response
+type nfsMonitorFreeDiskSizeResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Data *naked.MonitorValues `json:",omitempty"`
 }
 
-// NFSMonitorInterfaceRequestEnvelope is envelop of API request
-type NFSMonitorInterfaceRequestEnvelope struct {
+// nfsMonitorInterfaceRequestEnvelope is envelop of API request
+type nfsMonitorInterfaceRequestEnvelope struct {
 	Start *time.Time `json:",omitempty"`
 	End   *time.Time `json:",omitempty"`
 }
 
-// NFSMonitorInterfaceResponseEnvelope is envelop of API response
-type NFSMonitorInterfaceResponseEnvelope struct {
+// nfsMonitorInterfaceResponseEnvelope is envelop of API response
+type nfsMonitorInterfaceResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Data *naked.MonitorValues `json:",omitempty"`
 }
 
-// NoteFindRequestEnvelope is envelop of API request
-type NoteFindRequestEnvelope struct {
+// noteFindRequestEnvelope is envelop of API request
+type noteFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -606,8 +606,8 @@ type NoteFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// NoteFindResponseEnvelope is envelop of API response
-type NoteFindResponseEnvelope struct {
+// noteFindResponseEnvelope is envelop of API response
+type noteFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -615,42 +615,42 @@ type NoteFindResponseEnvelope struct {
 	Notes []*naked.Note `json:",omitempty"`
 }
 
-// NoteCreateRequestEnvelope is envelop of API request
-type NoteCreateRequestEnvelope struct {
+// noteCreateRequestEnvelope is envelop of API request
+type noteCreateRequestEnvelope struct {
 	Note *naked.Note `json:",omitempty"`
 }
 
-// NoteCreateResponseEnvelope is envelop of API response
-type NoteCreateResponseEnvelope struct {
+// noteCreateResponseEnvelope is envelop of API response
+type noteCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Note *naked.Note `json:",omitempty"`
 }
 
-// NoteReadResponseEnvelope is envelop of API response
-type NoteReadResponseEnvelope struct {
+// noteReadResponseEnvelope is envelop of API response
+type noteReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Note *naked.Note `json:",omitempty"`
 }
 
-// NoteUpdateRequestEnvelope is envelop of API request
-type NoteUpdateRequestEnvelope struct {
+// noteUpdateRequestEnvelope is envelop of API request
+type noteUpdateRequestEnvelope struct {
 	Note *naked.Note `json:",omitempty"`
 }
 
-// NoteUpdateResponseEnvelope is envelop of API response
-type NoteUpdateResponseEnvelope struct {
+// noteUpdateResponseEnvelope is envelop of API response
+type noteUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Note *naked.Note `json:",omitempty"`
 }
 
-// ServerFindRequestEnvelope is envelop of API request
-type ServerFindRequestEnvelope struct {
+// serverFindRequestEnvelope is envelop of API request
+type serverFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -659,8 +659,8 @@ type ServerFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// ServerFindResponseEnvelope is envelop of API response
-type ServerFindResponseEnvelope struct {
+// serverFindResponseEnvelope is envelop of API response
+type serverFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -668,87 +668,87 @@ type ServerFindResponseEnvelope struct {
 	Servers []*naked.Server `json:",omitempty"`
 }
 
-// ServerCreateRequestEnvelope is envelop of API request
-type ServerCreateRequestEnvelope struct {
+// serverCreateRequestEnvelope is envelop of API request
+type serverCreateRequestEnvelope struct {
 	Server *naked.Server `json:",omitempty"`
 }
 
-// ServerCreateResponseEnvelope is envelop of API response
-type ServerCreateResponseEnvelope struct {
+// serverCreateResponseEnvelope is envelop of API response
+type serverCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Server *naked.Server `json:",omitempty"`
 }
 
-// ServerReadResponseEnvelope is envelop of API response
-type ServerReadResponseEnvelope struct {
+// serverReadResponseEnvelope is envelop of API response
+type serverReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Server *naked.Server `json:",omitempty"`
 }
 
-// ServerUpdateRequestEnvelope is envelop of API request
-type ServerUpdateRequestEnvelope struct {
+// serverUpdateRequestEnvelope is envelop of API request
+type serverUpdateRequestEnvelope struct {
 	Server *naked.Server `json:",omitempty"`
 }
 
-// ServerUpdateResponseEnvelope is envelop of API response
-type ServerUpdateResponseEnvelope struct {
+// serverUpdateResponseEnvelope is envelop of API response
+type serverUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Server *naked.Server `json:",omitempty"`
 }
 
-// ServerChangePlanRequestEnvelope is envelop of API request
-type ServerChangePlanRequestEnvelope struct {
+// serverChangePlanRequestEnvelope is envelop of API request
+type serverChangePlanRequestEnvelope struct {
 	CPU                  int                   `json:",omitempty"`
 	MemoryMB             int                   `json:",omitempty"`
 	ServerPlanGeneration types.EPlanGeneration `json:",omitempty"`
 	ServerPlanCommitment types.ECommitment     `json:",omitempty"`
 }
 
-// ServerChangePlanResponseEnvelope is envelop of API response
-type ServerChangePlanResponseEnvelope struct {
+// serverChangePlanResponseEnvelope is envelop of API response
+type serverChangePlanResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Server *naked.Server `json:",omitempty"`
 }
 
-// ServerInsertCDROMRequestEnvelope is envelop of API request
-type ServerInsertCDROMRequestEnvelope struct {
+// serverInsertCDROMRequestEnvelope is envelop of API request
+type serverInsertCDROMRequestEnvelope struct {
 	CDROM *naked.CDROM `json:",omitempty"`
 }
 
-// ServerEjectCDROMRequestEnvelope is envelop of API request
-type ServerEjectCDROMRequestEnvelope struct {
+// serverEjectCDROMRequestEnvelope is envelop of API request
+type serverEjectCDROMRequestEnvelope struct {
 	CDROM *naked.CDROM `json:",omitempty"`
 }
 
-// ServerShutdownRequestEnvelope is envelop of API request
-type ServerShutdownRequestEnvelope struct {
+// serverShutdownRequestEnvelope is envelop of API request
+type serverShutdownRequestEnvelope struct {
 	Force bool `json:",omitempty"`
 }
 
-// ServerMonitorRequestEnvelope is envelop of API request
-type ServerMonitorRequestEnvelope struct {
+// serverMonitorRequestEnvelope is envelop of API request
+type serverMonitorRequestEnvelope struct {
 	Start *time.Time `json:",omitempty"`
 	End   *time.Time `json:",omitempty"`
 }
 
-// ServerMonitorResponseEnvelope is envelop of API response
-type ServerMonitorResponseEnvelope struct {
+// serverMonitorResponseEnvelope is envelop of API response
+type serverMonitorResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Data *naked.MonitorValues `json:",omitempty"`
 }
 
-// SwitchFindRequestEnvelope is envelop of API request
-type SwitchFindRequestEnvelope struct {
+// switchFindRequestEnvelope is envelop of API request
+type switchFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -757,8 +757,8 @@ type SwitchFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// SwitchFindResponseEnvelope is envelop of API response
-type SwitchFindResponseEnvelope struct {
+// switchFindResponseEnvelope is envelop of API response
+type switchFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -766,42 +766,42 @@ type SwitchFindResponseEnvelope struct {
 	Switches []*naked.Switch `json:",omitempty"`
 }
 
-// SwitchCreateRequestEnvelope is envelop of API request
-type SwitchCreateRequestEnvelope struct {
+// switchCreateRequestEnvelope is envelop of API request
+type switchCreateRequestEnvelope struct {
 	Switch *naked.Switch `json:",omitempty"`
 }
 
-// SwitchCreateResponseEnvelope is envelop of API response
-type SwitchCreateResponseEnvelope struct {
+// switchCreateResponseEnvelope is envelop of API response
+type switchCreateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Switch *naked.Switch `json:",omitempty"`
 }
 
-// SwitchReadResponseEnvelope is envelop of API response
-type SwitchReadResponseEnvelope struct {
+// switchReadResponseEnvelope is envelop of API response
+type switchReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Switch *naked.Switch `json:",omitempty"`
 }
 
-// SwitchUpdateRequestEnvelope is envelop of API request
-type SwitchUpdateRequestEnvelope struct {
+// switchUpdateRequestEnvelope is envelop of API request
+type switchUpdateRequestEnvelope struct {
 	Switch *naked.Switch `json:",omitempty"`
 }
 
-// SwitchUpdateResponseEnvelope is envelop of API response
-type SwitchUpdateResponseEnvelope struct {
+// switchUpdateResponseEnvelope is envelop of API response
+type switchUpdateResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Switch *naked.Switch `json:",omitempty"`
 }
 
-// ZoneFindRequestEnvelope is envelop of API request
-type ZoneFindRequestEnvelope struct {
+// zoneFindRequestEnvelope is envelop of API request
+type zoneFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
 	From    int                    `json:",omitempty"`
 	Sort    []string               `json:",omitempty"`
@@ -810,8 +810,8 @@ type ZoneFindRequestEnvelope struct {
 	Exclude []string               `json:",omitempty"`
 }
 
-// ZoneFindResponseEnvelope is envelop of API response
-type ZoneFindResponseEnvelope struct {
+// zoneFindResponseEnvelope is envelop of API response
+type zoneFindResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
@@ -819,8 +819,8 @@ type ZoneFindResponseEnvelope struct {
 	Zones []*naked.Zone `json:",omitempty"`
 }
 
-// ZoneReadResponseEnvelope is envelop of API response
-type ZoneReadResponseEnvelope struct {
+// zoneReadResponseEnvelope is envelop of API response
+type zoneReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 


### PR DESCRIPTION
( fixes #25 )

エンベロープstructの命名規則を変更しエクスポートしないようにする。